### PR TITLE
common automatic update

### DIFF
--- a/common/.github/workflows/chart-branches.yml
+++ b/common/.github/workflows/chart-branches.yml
@@ -1,0 +1,118 @@
+---
+name: Create per-chart branches
+
+# We only run this job on the charts that will be later moved to full blown charts
+# We also want to run the subtree comand only for the charts that have been actually changed
+# because git subtree split is a bit of an expensive operation
+# github actions do not support yaml anchors so there is more duplication than usual
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'acm/**'
+      - 'golang-external-secrets/**'
+      - 'hashicorp-vault/**'
+      - 'letsencrypt/**'
+      - 'clustergroup/**'
+
+jobs:
+  changes:
+    name: Figure out per-chart changes
+    if: github.repository == 'validatedpatterns/common'
+    runs-on: ubuntu-latest
+    permissions: read-all
+    outputs:
+      acm: ${{ steps.filter.outputs.acm }}
+      golang-external-secrets: ${{ steps.filter.outputs.golang-external-secrets }}
+      hashicorp-vault: ${{ steps.filter.outputs.hashicorp-vault }}
+      letsencrypt: ${{ steps.filter.outputs.letsencrypt }}
+      clustergroup: ${{ steps.filter.outputs.clustergroup }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            acm:
+              - 'acm/**'
+            golang-external-secrets:
+              - 'golang-external-secrets/**'
+            hashicorp-vault:
+              - 'hashicorp-vault/**'
+            letsencrypt:
+              - 'letsencrypt/**'
+            clustergroup:
+              - 'clustergroup/**'
+
+  acm:
+    needs: changes
+    if: |
+      ${{ needs.changes.outputs.acm == 'true' }} &&
+      github.repository == 'validatedpatterns/common'
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: acm
+      target_repository: validatedpatterns/acm-chart
+    secrets: inherit
+
+  golang-external-secrets:
+    needs: changes
+    if: |
+      ${{ needs.changes.outputs.golang-external-secrets == 'true' }} &&
+      github.repository == 'validatedpatterns/common'
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: golang-external-secrets
+      target_repository: validatedpatterns/golang-external-secrets-chart
+    secrets: inherit
+
+  hashicorp-vault:
+    needs: changes
+    if: |
+      ${{ needs.changes.outputs.hashicorp-vault == 'true' }} &&
+      github.repository == 'validatedpatterns/common'
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: hashicorp-vault
+      target_repository: validatedpatterns/hashicorp-vault-chart
+    secrets: inherit
+
+  letsencrypt:
+    needs: changes
+    if: |
+      ${{ needs.changes.outputs.letsencrypt == 'true' }} &&
+      github.repository == 'validatedpatterns/common'
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: letsencrypt
+      target_repository: validatedpatterns/letsencrypt-chart
+    secrets: inherit
+
+  clustergroup:
+    needs: changes
+    if: |
+      ${{ needs.changes.outputs.clustergroup == 'true' }} &&
+      github.repository == 'validatedpatterns/common'
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: clustergroup
+      target_repository: validatedpatterns/clustergroup-chart
+    secrets: inherit

--- a/common/.github/workflows/chart-split.yml
+++ b/common/.github/workflows/chart-split.yml
@@ -1,0 +1,38 @@
+---
+name: Split into chart repo branches
+
+on:
+  workflow_call:
+    inputs:
+      chart_name:
+        required: true
+        type: string
+      target_repository:
+        required: true
+        type: string
+
+jobs:
+  split_chart:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CHARTS_REPOS_TOKEN }}
+
+      - name: Run git subtree split and push
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHARTS_REPOS_TOKEN }}
+        run: |
+          set -e
+          N="${{ inputs.chart_name }}"
+          B="${N}-main-single-chart"
+          git push origin -d "${B}" || /bin/true
+          git subtree split -P "${N}" -b "${B}"
+          git push -f -u origin "${B}"
+          #git clone https://validatedpatterns:${GITHUB_TOKEN}@github.com/validatedpatterns/common.git -b "acm-main-single-chart" --single-branch
+          git push --force https://validatedpatterns:"${GITHUB_TOKEN}"@github.com/${{ inputs.target_repository }}.git "${B}:main"

--- a/common/.github/workflows/linter.yml
+++ b/common/.github/workflows/linter.yml
@@ -35,9 +35,9 @@ jobs:
           fetch-depth: 0
       - name: Setup helm
         uses: azure/setup-helm@v3
-        # with:
-        #   version: '<version>' # default is latest stable
-        id: install
+        with:
+          version: 'v3.12.3'
+
 
       ################################
       # Run Linter against code base #

--- a/common/acm/.github/workflows/update-helm-repo.yml
+++ b/common/acm/.github/workflows/update-helm-repo.yml
@@ -1,0 +1,29 @@
+# This invokes the workflow named 'publish-charts' in the umbrella repo
+# It expects to have a secret called CHARTS_REPOS_TOKEN which contains
+# the GitHub token that has permissions to invoke workflows and commit code
+# inside the umbrella-repo.
+# The following fine-grained permissions were used in testing and were limited
+# to the umbrella repo only:
+# - Actions: r/w
+# - Commit statuses: r/w
+# - Contents: r/w
+# - Deployments: r/w
+# - Pages: r/w
+
+name: vp-patterns/update-helm-repo
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  helmlint:
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    permissions:
+      contents: read
+
+  update-helm-repo:
+    needs: [helmlint]
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    permissions: read-all
+    secrets: inherit

--- a/common/acm/Chart.yaml
+++ b/common/acm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: A Helm chart to configure Advanced Cluster Manager for OpenShift
+description: A Helm chart to configure Advanced Cluster Manager for OpenShift.
 keywords:
 - pattern
 name: acm

--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -44,6 +44,9 @@ spec:
                       ignoreMissingValueFiles: true
                       valueFiles:
                       {{- include "acm.app.policies.valuefiles" . | nindent 24 }}
+                      {{- range $valueFile := $.Values.global.extraValueFiles }}
+                      - {{ $valueFile | quote }}
+                      {{- end }}
                       {{- range $valueFile := .extraValueFiles }}
                       - {{ $valueFile | quote }}
                       {{- end }}

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -3,6 +3,7 @@ main:
     channel: "gitops-1.8"
 
 global:
+  extraValueFiles: []
   pattern: none
   repoURL: none
   targetRevision: main

--- a/common/clustergroup/.github/workflows/update-helm-repo.yml
+++ b/common/clustergroup/.github/workflows/update-helm-repo.yml
@@ -1,0 +1,29 @@
+# This invokes the workflow named 'publish-charts' in the umbrella repo
+# It expects to have a secret called CHARTS_REPOS_TOKEN which contains
+# the GitHub token that has permissions to invoke workflows and commit code
+# inside the umbrella-repo.
+# The following fine-grained permissions were used in testing and were limited
+# to the umbrella repo only:
+# - Actions: r/w
+# - Commit statuses: r/w
+# - Contents: r/w
+# - Deployments: r/w
+# - Pages: r/w
+
+name: vp-patterns/update-helm-repo
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  helmlint:
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    permissions:
+      contents: read
+
+  update-helm-repo:
+    needs: [helmlint]
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    permissions: read-all
+    secrets: inherit

--- a/common/clustergroup/Chart.yaml
+++ b/common/clustergroup/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: A Helm chart to create per-clustergroup ArgoCD applications and any required namespaces or subscriptions
+description: A Helm chart to create per-clustergroup ArgoCD applications and any required namespaces or subscriptions.
 keywords:
 - pattern
 name: clustergroup

--- a/common/clustergroup/templates/_helpers.tpl
+++ b/common/clustergroup/templates/_helpers.tpl
@@ -39,4 +39,9 @@ Default always defined valueFiles to be included in Applications
 {{- if $.Values.global.clusterVersion }}
 - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
 {{- end }}
+{{- if $.Values.global.extraValueFiles }}
+{{- range $.Values.global.extraValueFiles }}
+- {{ . | quote }}
+{{- end }} {{/* range $.Values.global.extraValueFiles */}}
+{{- end }} {{/* if $.Values.global.extraValueFiles */}}
 {{- end }} {{/* clustergroup.app.globalvalues.valuefiles */}}

--- a/common/clustergroup/templates/plumbing/applications.yaml
+++ b/common/clustergroup/templates/plumbing/applications.yaml
@@ -4,7 +4,8 @@
 {{- $namespace = "openshift-gitops" }}
 {{- end }}
 {{- range .Values.clusterGroup.applications }}
-{{- if or (.generators) (.generatorFile) (.useGeneratorValues) (.destinationServer) (.destinationNamespace) }}
+{{- if .disabled }} {{- /* This allows us to null out an Application entry by specifying disabled: true in an override file */}}
+{{- else if or (.generators) (.generatorFile) (.useGeneratorValues) (.destinationServer) (.destinationNamespace) }}
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/common/clustergroup/values.yaml
+++ b/common/clustergroup/values.yaml
@@ -1,4 +1,5 @@
 global:
+  extraValueFiles: []
   pattern: common
   targetRevision: main
   options:

--- a/common/golang-external-secrets/.github/workflows/update-helm-repo.yml
+++ b/common/golang-external-secrets/.github/workflows/update-helm-repo.yml
@@ -1,0 +1,29 @@
+# This invokes the workflow named 'publish-charts' in the umbrella repo
+# It expects to have a secret called CHARTS_REPOS_TOKEN which contains
+# the GitHub token that has permissions to invoke workflows and commit code
+# inside the umbrella-repo.
+# The following fine-grained permissions were used in testing and were limited
+# to the umbrella repo only:
+# - Actions: r/w
+# - Commit statuses: r/w
+# - Contents: r/w
+# - Deployments: r/w
+# - Pages: r/w
+
+name: vp-patterns/update-helm-repo
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  helmlint:
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    permissions:
+      contents: read
+
+  update-helm-repo:
+    needs: [helmlint]
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    permissions: read-all
+    secrets: inherit

--- a/common/golang-external-secrets/Chart.yaml
+++ b/common/golang-external-secrets/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: A Helm chart to configure the golang-based external-secrets
+description: A Helm chart to configure the golang-based external-secrets.
 keywords:
 - pattern
 name: golang-external-secrets

--- a/common/hashicorp-vault/.github/workflows/update-helm-repo.yml
+++ b/common/hashicorp-vault/.github/workflows/update-helm-repo.yml
@@ -1,0 +1,29 @@
+# This invokes the workflow named 'publish-charts' in the umbrella repo
+# It expects to have a secret called CHARTS_REPOS_TOKEN which contains
+# the GitHub token that has permissions to invoke workflows and commit code
+# inside the umbrella-repo.
+# The following fine-grained permissions were used in testing and were limited
+# to the umbrella repo only:
+# - Actions: r/w
+# - Commit statuses: r/w
+# - Contents: r/w
+# - Deployments: r/w
+# - Pages: r/w
+
+name: vp-patterns/update-helm-repo
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  helmlint:
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    permissions:
+      contents: read
+
+  update-helm-repo:
+    needs: [helmlint]
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    permissions: read-all
+    secrets: inherit

--- a/common/hashicorp-vault/Chart.yaml
+++ b/common/hashicorp-vault/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: A Helm chart to configure Hashicorp's vault
+description: A Helm chart to configure Hashicorp's vault.
 keywords:
 - pattern
 name: hashicorp-vault

--- a/common/hashicorp-vault/values.yaml
+++ b/common/hashicorp-vault/values.yaml
@@ -8,7 +8,6 @@ vault:
     enabled: false
   ui:
     enabled: true
-    serviceType: "LoadBalancer"
   server:
     extraEnvironmentVars:
       VAULT_CACERT: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/common/letsencrypt/.github/workflows/update-helm-repo.yml
+++ b/common/letsencrypt/.github/workflows/update-helm-repo.yml
@@ -1,0 +1,29 @@
+# This invokes the workflow named 'publish-charts' in the umbrella repo
+# It expects to have a secret called CHARTS_REPOS_TOKEN which contains
+# the GitHub token that has permissions to invoke workflows and commit code
+# inside the umbrella-repo.
+# The following fine-grained permissions were used in testing and were limited
+# to the umbrella repo only:
+# - Actions: r/w
+# - Commit statuses: r/w
+# - Contents: r/w
+# - Deployments: r/w
+# - Pages: r/w
+
+name: vp-patterns/update-helm-repo
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  helmlint:
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    permissions:
+      contents: read
+
+  update-helm-repo:
+    needs: [helmlint]
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    permissions: read-all
+    secrets: inherit

--- a/common/letsencrypt/Chart.yaml
+++ b/common/letsencrypt/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: letsencrypt
-description: A Helm chart to add letsencrypt support to Validated Patterns
+description: A Helm chart to add letsencrypt support to Validated Patterns.
 
 type: application
 

--- a/common/operator-install/templates/pattern.yaml
+++ b/common/operator-install/templates/pattern.yaml
@@ -14,7 +14,13 @@ spec:
 {{- if .Values.main.extraParameters }}
   extraParameters:
 {{- range .Values.main.extraParameters }}
-  - name: {{ .name }}
-    value: {{ .value }}
-{{- end }}
-{{- end }}
+  - name: {{ .name | quote }}
+    value: {{ .value | quote }}
+{{- end }} {{/* range .Values.main.extraParameters */}}
+{{- end }} {{/* if .Values.main.extraParameters */}}
+{{- if .Values.global.extraValueFiles }}
+  extraValueFiles:
+{{- range .Values.global.extraValueFiles }}
+  - {{ . | quote }}
+{{- end }} {{/* range .Values.global.extraValueFiles */}}
+{{- end }} {{/* if .Values.global.extraValueFiles */}}

--- a/common/operator-install/values.yaml
+++ b/common/operator-install/values.yaml
@@ -1,3 +1,6 @@
+global:
+  extraValueFiles: []
+
 main:
   git:
     repoURL: https://github.com/pattern-clone/mypattern

--- a/common/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/common/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -136,6 +136,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       git:
         account: hybrid-cloud-patterns
         dev_revision: main
@@ -407,7 +408,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-factory.yaml"
+      - "/values-factory.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/common/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/common/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -297,6 +297,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       git:
         account: hybrid-cloud-patterns
         dev_revision: main
@@ -682,7 +683,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -737,7 +738,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -783,7 +784,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -829,7 +830,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -905,7 +906,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -951,7 +952,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1022,7 +1023,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/common/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -284,6 +284,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       git:
         account: hybrid-cloud-patterns
         dev_revision: main
@@ -627,7 +628,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -673,7 +674,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -719,7 +720,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -765,7 +766,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -811,7 +812,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -857,7 +858,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -903,7 +904,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -949,7 +950,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1013,7 +1014,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1059,7 +1060,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1105,7 +1106,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1160,7 +1161,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1215,7 +1216,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/common/tests/clustergroup-naked.expected.yaml
+++ b/common/tests/clustergroup-naked.expected.yaml
@@ -65,6 +65,7 @@ data:
       targetCluster: in-cluster
     enabled: all
     global:
+      extraValueFiles: []
       options:
         applicationRetryLimit: 20
         installPlanApproval: Automatic

--- a/common/tests/clustergroup-normal.expected.yaml
+++ b/common/tests/clustergroup-normal.expected.yaml
@@ -193,6 +193,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       git:
         account: hybrid-cloud-patterns
         dev_revision: main
@@ -537,7 +538,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-example.yaml"
+      - "/values-example.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -592,7 +593,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-example.yaml"
+      - "/values-example.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/common/tests/hashicorp-vault-industrial-edge-factory.expected.yaml
+++ b/common/tests/hashicorp-vault-industrial-edge-factory.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/common/tests/hashicorp-vault-industrial-edge-hub.expected.yaml
+++ b/common/tests/hashicorp-vault-industrial-edge-hub.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/common/tests/hashicorp-vault-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/hashicorp-vault-medical-diagnosis-hub.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/common/tests/hashicorp-vault-naked.expected.yaml
+++ b/common/tests/hashicorp-vault-naked.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/common/tests/hashicorp-vault-normal.expected.yaml
+++ b/common/tests/hashicorp-vault-normal.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/common-clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/common-clustergroup-industrial-edge-factory.expected.yaml
@@ -136,6 +136,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       hubClusterDomain: apps.hub.example.com
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
@@ -402,7 +403,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-factory.yaml"
+      - "/values-factory.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/tests/common-clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/common-clustergroup-industrial-edge-hub.expected.yaml
@@ -297,6 +297,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       hubClusterDomain: apps.hub.example.com
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
@@ -677,7 +678,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -732,7 +733,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -778,7 +779,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -824,7 +825,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -900,7 +901,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -946,7 +947,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1017,7 +1018,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-datacenter.yaml"
+      - "/values-datacenter.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/tests/common-clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-clustergroup-medical-diagnosis-hub.expected.yaml
@@ -284,6 +284,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       hubClusterDomain: apps.hub.example.com
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
@@ -622,7 +623,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -668,7 +669,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -714,7 +715,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -760,7 +761,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -806,7 +807,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -852,7 +853,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -898,7 +899,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -944,7 +945,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1008,7 +1009,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1054,7 +1055,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1100,7 +1101,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1155,7 +1156,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -1210,7 +1211,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-hub.yaml"
+      - "/values-hub.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/tests/common-clustergroup-naked.expected.yaml
+++ b/tests/common-clustergroup-naked.expected.yaml
@@ -65,6 +65,7 @@ data:
       targetCluster: in-cluster
     enabled: all
     global:
+      extraValueFiles: []
       options:
         applicationRetryLimit: 20
         installPlanApproval: Automatic

--- a/tests/common-clustergroup-normal.expected.yaml
+++ b/tests/common-clustergroup-normal.expected.yaml
@@ -193,6 +193,7 @@ data:
     enabled: all
     global:
       clusterDomain: region.example.com
+      extraValueFiles: []
       hubClusterDomain: apps.hub.example.com
       localClusterDomain: apps.region.example.com
       multiClusterTarget: all
@@ -532,7 +533,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-example.yaml"
+      - "/values-example.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -587,7 +588,7 @@ spec:
       ignoreMissingValueFiles: true
       valueFiles:
       - "/values-global.yaml"
-      - "/values-example.yaml"
+      - "/values-example.yaml" 
       parameters:
         - name: global.repoURL
           value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/tests/common-hashicorp-vault-industrial-edge-factory.expected.yaml
+++ b/tests/common-hashicorp-vault-industrial-edge-factory.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/common-hashicorp-vault-industrial-edge-hub.expected.yaml
+++ b/tests/common-hashicorp-vault-industrial-edge-hub.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/common-hashicorp-vault-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-hashicorp-vault-medical-diagnosis-hub.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/common-hashicorp-vault-naked.expected.yaml
+++ b/tests/common-hashicorp-vault-naked.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/common-hashicorp-vault-normal.expected.yaml
+++ b/tests/common-hashicorp-vault-normal.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.


### PR DESCRIPTION
- Add workflow to split helm charts into their own repo
- Small test for the workflow towards single chart repos
- Small test for the workflow towards single chart repos (part 2)
- Simplify split workflow
- Small test for the workflow towards single chart repos (part 3)
- Tiny change to trigger split workflow
- Add initial helm releasing workflow for acm chart
- Add helm repo updating workflow in the per-chart workflows folder
- Fix up CI superlinter on github actions
- Fix tests and make .disabled explicit
- Make sure we run the split workflow only when the changes land in validatedpatterns/common
- Update tests. We get an extra (non-impacting whitespace) with the new code
- re-add logic for extravaluefiles
- Add more tests for variable definedness/truth
- Switch helm to v3.12.3 in CI
- Unroll global.extraValueFiles in application-policies directly due to namespacing in the _helper.tpl
- Re-add code to operator-install to understand global.extraValueFiles
- Make sure to add dollar sign
- Correct ifs and ranges in pattern, add comments
- Also quote name and value values
- Drop vault.ui.serviceType: "LoadBalancer"
- Fix up common/ tests
