### PR TITLE
common automatic update

### DIFF
--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -69,6 +69,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}'
+                      - name: global.localClusterName
+                        value: '{{ `{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}` }}'
                       - name: global.clusterPlatform
                         value: {{ $.Values.global.clusterPlatform }}
                       - name: clusterGroup.name

--- a/common/clustergroup/Chart.yaml
+++ b/common/clustergroup/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart to create per-clustergroup ArgoCD applications and any
 keywords:
 - pattern
 name: clustergroup
-version: 0.0.3
+version: 0.0.4

--- a/common/clustergroup/templates/imperative/job.yaml
+++ b/common/clustergroup/templates/imperative/job.yaml
@@ -1,6 +1,6 @@
 {{- if not (eq .Values.enabled "plumbing") }}
 {{/* Define this if needed (jobs defined */}}
-{{- if (gt (len $.Values.clusterGroup.imperative.jobs) 0) -}}
+{{- if (and $.Values.clusterGroup.imperative (gt (len $.Values.clusterGroup.imperative.jobs) 0)) -}}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/common/operator-install/README.md
+++ b/common/operator-install/README.md
@@ -1,0 +1,4 @@
+# Update CRD
+
+In order to update the CRD, copy the following file from the last released patterns operator version:
+`cp -v patterns-operator/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml ./crds/`

--- a/common/operator-install/crds/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/common/operator-install/crds/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
-  creationTimestamp: null
   name: patterns.gitops.hybrid-cloud-patterns.io
 spec:
   group: gitops.hybrid-cloud-patterns.io
@@ -72,29 +72,9 @@ spec:
                 type: array
               gitOpsSpec:
                 properties:
-                  manualApproval:
-                    description: 'Require manual confirmation before installing and
-                      upgrading operators. Default: False'
-                    type: boolean
                   manualSync:
                     description: 'Require manual intervention before Argo will sync
                       new content. Default: False'
-                    type: boolean
-                  operatorCSV:
-                    description: Specific version of openshift-gitops to deploy.  Requires
-                      UseCSV=True
-                    type: string
-                  operatorChannel:
-                    description: 'Channel to deploy openshift-gitops from. Default:
-                      gitops-1.8'
-                    type: string
-                  operatorSource:
-                    description: 'Source to deploy openshift-gitops from. Default:
-                      redhat-operators'
-                    type: string
-                  useCSV:
-                    description: 'Dangerous. Force a specific version to be installed.
-                      Default: False'
                     type: boolean
                 type: object
               gitSpec:
@@ -163,8 +143,31 @@ spec:
           status:
             description: PatternStatus defines the observed state of Pattern
             properties:
+              analyticsSent:
+                type: boolean
+              analyticsUUID:
+                type: string
               appClusterDomain:
                 type: string
+              applications:
+                items:
+                  description: PatternApplicationInfo defines the Applications Status
+                    for the Pattern. This structure is part of the PatternStatus as
+                    an array The Application Status will be included as part of the
+                    Observed state of Pattern
+                  properties:
+                    healthMessage:
+                      type: string
+                    healthStatus:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    syncStatus:
+                      type: string
+                  type: object
+                type: array
               clusterDomain:
                 type: string
               clusterID:
@@ -218,9 +221,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -27,7 +27,7 @@ fi
 
 # Do not quote the ${KUBECONF_ENV} below, otherwise we will pass '' to podman
 # which will be confused
-podman run -it --rm \
+podman run -it --rm --pull=newer \
 	--security-opt label=disable \
 	-e EXTRA_HELM_OPTS \
 	-e KUBECONFIG \

--- a/common/tests/acm-industrial-edge-hub.expected.yaml
+++ b/common/tests/acm-industrial-edge-hub.expected.yaml
@@ -233,6 +233,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name

--- a/common/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -224,6 +224,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -627,6 +627,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name
@@ -721,6 +723,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -233,6 +233,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -224,6 +224,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -627,6 +627,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name
@@ -721,6 +723,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
                       - name: global.clusterPlatform
                         value: aws
                       - name: clusterGroup.name


### PR DESCRIPTION
- Release clustergroup v0.0.4
- Add --pull=newer when running the container
- Allow imperative to be nil
- Push localClusterName to remote clusters too
- Update CRD for the operator
- Add a README containing the CRD update instructions
- Fix up tests after common rebase
