### PR TITLE
Enable multisource by default

### DIFF
--- a/tests/common-clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/common-clustergroup-industrial-edge-factory.expected.yaml
@@ -156,6 +156,8 @@ data:
       git:
         repoURL: https://github.com/pattern-clone/mypattern
         revision: main
+      multiSourceConfig:
+        enabled: true
     secretStore:
       kind: ClusterSecretStore
       name: vault-backend

--- a/tests/common-clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/common-clustergroup-industrial-edge-hub.expected.yaml
@@ -317,6 +317,8 @@ data:
       git:
         repoURL: https://github.com/pattern-clone/mypattern
         revision: main
+      multiSourceConfig:
+        enabled: true
     secretStore:
       kind: ClusterSecretStore
       name: vault-backend

--- a/tests/common-clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-clustergroup-medical-diagnosis-hub.expected.yaml
@@ -304,6 +304,8 @@ data:
       git:
         repoURL: https://github.com/pattern-clone/mypattern
         revision: main
+      multiSourceConfig:
+        enabled: true
     secretStore:
       kind: ClusterSecretStore
       name: vault-backend

--- a/tests/common-clustergroup-normal.expected.yaml
+++ b/tests/common-clustergroup-normal.expected.yaml
@@ -218,6 +218,8 @@ data:
       git:
         repoURL: https://github.com/pattern-clone/mypattern
         revision: main
+      multiSourceConfig:
+        enabled: true
     secretStore:
       kind: ClusterSecretStore
       name: vault-backend

--- a/tests/common-operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/common-operator-install-industrial-edge-factory.expected.yaml
@@ -29,7 +29,7 @@ spec:
     operatorChannel: gitops-1.8
     operatorSource: redhat-operators
   multiSourceConfig:
-    enabled: false
+    enabled: true
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/common-operator-install-industrial-edge-hub.expected.yaml
@@ -29,7 +29,7 @@ spec:
     operatorChannel: gitops-1.8
     operatorSource: redhat-operators
   multiSourceConfig:
-    enabled: false
+    enabled: true
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-operator-install-medical-diagnosis-hub.expected.yaml
@@ -29,7 +29,7 @@ spec:
     operatorChannel: gitops-1.8
     operatorSource: redhat-operators
   multiSourceConfig:
-    enabled: false
+    enabled: true
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-normal.expected.yaml
+++ b/tests/common-operator-install-normal.expected.yaml
@@ -29,7 +29,7 @@ spec:
     operatorChannel: gitops-1.8
     operatorSource: redhat-operators
   multiSourceConfig:
-    enabled: false
+    enabled: true
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -9,3 +9,6 @@ global:
 
 main:
   clusterGroupName: hub
+
+  multiSourceConfig:
+    enabled: true


### PR DESCRIPTION
This only affects the clustergroup chart. The other charts need to
be migrated manually.
