### PR TITLE
common automatic update

### DIFF
--- a/common/clustergroup/templates/core/operatorgroup.yaml
+++ b/common/clustergroup/templates/core/operatorgroup.yaml
@@ -5,7 +5,7 @@
 
   {{- if kindIs "map" $ns }}
   {{- range $k, $v := $ns }}{{- /* We loop here even though the map has always just one key */}}
-
+  {{- if $v.operatorGroup }}{{- /* Checks if the user sets operatorGroup: false */}}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -13,9 +13,15 @@ metadata:
   namespace: {{ $k }}
 spec:
   targetNamespaces:
+    {{- if (hasKey $v "targetNamespaces") }}
+      {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
+  - {{ . }}
+      {{- end }}{{- /* End range targetNamespaces */}}
+    {{- else }}
   - {{ $k }}
+    {{- end }}{{- /* End of if operatorGroup */}}
   {{- end }}{{- /* range $k, $v := $ns */}}
-
+  {{- end }}{{- /* End of if operatorGroup */}}
   {{- else if kindIs "string" $ns }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/common/clustergroup/values.schema.json
+++ b/common/clustergroup/values.schema.json
@@ -266,6 +266,13 @@
             "type": "string"
           }
         },
+        "operatorgroupExcludeTargetNS": {
+          "type": "array",
+          "description": "Specify the list of namespaces where the target namespace field in the corresponding operatorgroup object should be excluded.",
+          "items": {
+            "type": "string"
+          }
+        },
         "hostedSite": {
           "type": "object",
           "items": {

--- a/common/examples/values-example.yaml
+++ b/common/examples/values-example.yaml
@@ -23,12 +23,23 @@ clusterGroup:
       annotations:
         openshift.io/cluster-monitoring: "true"
         owner: "namespace owner"
-  - application-ci
-  - excludes-ci
+  - application-ci:
+      operatorGroup: true
+      targetNamespaces:
+        - application-ci
+        - other-namespace
+  - exclude-targetns:
+      operatorGroup: true
+      targetNamespaces:
+  - include-ci
+  - exclude-og
+  - totally-exclude-og:
+      operatorGroup: false
+  - include-default-og:
+      operatorGroup: true
 
   operatorgroupExcludes:
-  - excludes-ci
-
+  - exclude-og
 
   subscriptions:
     acm:

--- a/common/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/common/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -10,19 +10,21 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+{{- if .Values.golangExternalSecrets.caProvider.enabled }}
 {{ if .Values.clusterGroup.isHubCluster }}
       caProvider:
-        type: ConfigMap
-        name: kube-root-ca.crt
-        key: ca.crt
-        namespace: golang-external-secrets
+        type: {{ .Values.golangExternalSecrets.caProvider.hubCluster.type }}
+        name: {{ .Values.golangExternalSecrets.caProvider.hubCluster.name }}
+        key: {{ .Values.golangExternalSecrets.caProvider.hubCluster.key }}
+        namespace: {{ .Values.golangExternalSecrets.caProvider.hubCluster.namespace }}
 {{ else }}
       caProvider:
-        type: Secret
-        name: hub-ca
-        key: hub-kube-root-ca.crt
-        namespace: imperative
+        type: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.type }}
+        name: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.name }}
+        key: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.key }}
+        namespace: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.namespace }}
 {{ end }}
+{{- end }}
       auth:
         kubernetes:
 {{ if .Values.clusterGroup.isHubCluster }}

--- a/common/golang-external-secrets/values.yaml
+++ b/common/golang-external-secrets/values.yaml
@@ -1,6 +1,22 @@
 ---
+# Eventually we should aim to move these two under the golangExternalSecrets key
 mountPath: "hub"
 mountRole: "hub-role"
+
+golangExternalSecrets:
+  # This controls how ESO connects to vault
+  caProvider:
+    enabled: true # If vault is exposed via a route that is signed by a non internal CA you might want to disable this
+    hubCluster:
+      type: ConfigMap
+      name: kube-root-ca.crt
+      key: ca.crt
+      namespace: golang-external-secrets
+    nonhubCluster:
+      type: Secret
+      name: hub-ca
+      key: hub-kube-root-ca.crt
+      namespace: imperative
 
 global:
   hubClusterDomain: hub.example.com

--- a/common/tests/clustergroup-normal.expected.yaml
+++ b/common/tests/clustergroup-normal.expected.yaml
@@ -17,9 +17,18 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: application-ci
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
-  name: application-ci
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: exclude-targetns
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
 spec:
 ---
 # Source: clustergroup/templates/core/namespaces.yaml
@@ -28,7 +37,34 @@ kind: Namespace
 metadata:
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
-  name: excludes-ci
+  name: include-ci
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+  name: exclude-og
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: totally-exclude-og
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: include-default-og
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
 spec:
 ---
 # Source: clustergroup/templates/imperative/namespace.yaml
@@ -171,10 +207,22 @@ data:
           labels:
             kubernetes.io/os: linux
             openshift.io/node-selector: ""
-      - application-ci
-      - excludes-ci
+      - application-ci:
+          operatorGroup: true
+          targetNamespaces:
+          - application-ci
+          - other-namespace
+      - exclude-targetns:
+          operatorGroup: true
+          targetNamespaces: null
+      - include-ci
+      - exclude-og
+      - totally-exclude-og:
+          operatorGroup: false
+      - include-default-og:
+          operatorGroup: true
       operatorgroupExcludes:
-      - excludes-ci
+      - exclude-og
       projects:
       - datacenter
       sharedValueFiles:
@@ -1038,21 +1086,42 @@ spec:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: open-cluster-management-operator-group
-  namespace: open-cluster-management
-spec:
-  targetNamespaces:
-  - open-cluster-management
----
-# Source: clustergroup/templates/core/operatorgroup.yaml
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
   name: application-ci-operator-group
   namespace: application-ci
 spec:
   targetNamespaces:
   - application-ci
+  - other-namespace
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: exclude-targetns-operator-group
+  namespace: exclude-targetns
+spec:
+  targetNamespaces:
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: include-ci-operator-group
+  namespace: include-ci
+spec:
+  targetNamespaces:
+  - include-ci
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: include-default-og-operator-group
+  namespace: include-default-og
+spec:
+  targetNamespaces:
+  - include-default-og
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-clustergroup-normal.expected.yaml
+++ b/tests/common-clustergroup-normal.expected.yaml
@@ -17,9 +17,18 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: application-ci
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
-  name: application-ci
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: exclude-targetns
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
 spec:
 ---
 # Source: clustergroup/templates/core/namespaces.yaml
@@ -28,7 +37,34 @@ kind: Namespace
 metadata:
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
-  name: excludes-ci
+  name: include-ci
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+  name: exclude-og
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: totally-exclude-og
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: include-default-og
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
 spec:
 ---
 # Source: clustergroup/templates/imperative/namespace.yaml
@@ -171,10 +207,22 @@ data:
           labels:
             kubernetes.io/os: linux
             openshift.io/node-selector: ""
-      - application-ci
-      - excludes-ci
+      - application-ci:
+          operatorGroup: true
+          targetNamespaces:
+          - application-ci
+          - other-namespace
+      - exclude-targetns:
+          operatorGroup: true
+          targetNamespaces: null
+      - include-ci
+      - exclude-og
+      - totally-exclude-og:
+          operatorGroup: false
+      - include-default-og:
+          operatorGroup: true
       operatorgroupExcludes:
-      - excludes-ci
+      - exclude-og
       projects:
       - datacenter
       sharedValueFiles:
@@ -1035,21 +1083,42 @@ spec:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: open-cluster-management-operator-group
-  namespace: open-cluster-management
-spec:
-  targetNamespaces:
-  - open-cluster-management
----
-# Source: clustergroup/templates/core/operatorgroup.yaml
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
   name: application-ci-operator-group
   namespace: application-ci
 spec:
   targetNamespaces:
   - application-ci
+  - other-namespace
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: exclude-targetns-operator-group
+  namespace: exclude-targetns
+spec:
+  targetNamespaces:
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: include-ci-operator-group
+  namespace: include-ci
+spec:
+  targetNamespaces:
+  - include-ci
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: include-default-og-operator-group
+  namespace: include-default-og
+spec:
+  targetNamespaces:
+  - include-default-og
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
- Adding key to exclude target namespace in operatorgroup
- Added target namespace logic to namespace map case
- Changed description in schema
- Added example to operatorgroupExcludeTargetNS
- Fixing CI tests
- - Removed new key operatorgroupExludeTargetNS - Added key to namespace map entry excludeOperatorGroupTargetNS.
- Updates to CI
- Adding option to include/exclude targetNamespaces in OperatorGroup
- Updated CI tests
- - Updated structure for supporting OperatorGroup's per suggestion of decoupling operatorGroup and targetNamespaces.   Example:     - exclude-targetns:       operatorGroup: true       targetNamespaces: - Continues to support operatorgroupExcludes - Updated CI tests
- Update logic to fix multiple targetNamespaces
- Fix ci issues
- Parametrize ESO caProvider fields
- Simplify target namespace logic
- Update tests after common rebase
