### PR TITLE
common automatic update

### DIFF
--- a/common/ansible/roles/iib_ci/tasks/mirror-related-images.yml
+++ b/common/ansible/roles/iib_ci/tasks/mirror-related-images.yml
@@ -89,7 +89,7 @@
     image_urls: "{{ image_urls | default({}) | combine({item:
       {'mirrordest': mirror_dest + item | basename,
        'mirrordest_nosha': (mirror_dest + item | basename) | regex_replace('@.*$', ''),
-       'mirrordest_tag': iib}}, recursive=true) }}"
+       'mirrordest_tag': 'tag-' + item | basename | regex_replace('^.*@sha256:', '')}}, recursive=true) }}"
   loop: "{{ all_images }}"
   when: use_internal_registry
 


### PR DESCRIPTION
- - Fix: bug in task TASK [iib_ci : Mirror all the needed images]
- - Updated the mirrordest_tag to use the sha256 of the image instead of the IIB number.
- Restored mirror template to original implementation
