### PR TITLE
Switch to using release-2.9 for acm

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -11,7 +11,7 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.8
+      channel: release-2.9
       #csv: advanced-cluster-management.v2.6.1
   projects:
     - hub


### PR DESCRIPTION
Since we dropped OCP 4.11 support we can now switch to this version
which is the default nowadays
