### PR TITLE
Rework IIB loading support

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -113,9 +113,7 @@ secrets-backend-none: ## Edits values files to remove secrets manager + ESO
 .PHONY: load-iib
 load-iib: ## CI target to install Index Image Bundles
 	@set -e; if [ x$(INDEX_IMAGES) != x ]; then \
-		for IIB in $(shell echo $(INDEX_IMAGES) | tr ',' '\n'); do \
-			INDEX_IMAGE="$${IIB}" ansible-playbook common/ansible/playbooks/iib-ci/iib-ci.yaml; \
-		done; \
+		ansible-playbook common/ansible/playbooks/iib-ci/iib-ci.yaml; \
 	else \
 		echo "No INDEX_IMAGES defined. Bailing out"; \
 		exit 1; \

--- a/common/ansible/roles/iib_ci/README.md
+++ b/common/ansible/roles/iib_ci/README.md
@@ -56,14 +56,6 @@ make EXTRA_HELM_OPTS="--set main.extraParameters[0].name=clusterGroup.subscripti
 
 *Note*: In this case `acm` is the name of the subscription in `values-hub.yaml`
 
-### OCP 4.13 and onwards
-
-Since 4.13 supports an internal registry that can cope with v2 docker manifests, we
-use that. Run `make iib` with the following environment variables set:
-
-* `INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:492329`
-* `KUBEADMINPASS="11111-22222-33333-44444"`
-
 ## Useful commands
 
 * List IIBs for an operator:

--- a/common/ansible/roles/iib_ci/defaults/main.yml
+++ b/common/ansible/roles/iib_ci/defaults/main.yml
@@ -1,5 +1,5 @@
 rh_internal_registry: registry-proxy.engineering.redhat.com
-iib_image: "{{ lookup('env', 'INDEX_IMAGE') }}"
+iib_images: "{{ lookup('env', 'INDEX_IMAGES') }}"
 
 kubeadminpass: "{{ lookup('env', 'KUBEADMINPASS') }}"
 

--- a/common/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
+++ b/common/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
@@ -2,9 +2,9 @@
 # the operator name is defined in the variable "item". This
 # set of tasks is to be included in a loop that goes over the
 # needed operators
-- name: Get default channel in the IIB for "{{ item }}"
+- name: Get default channel in the IIB for "{{ item.key }}"
   ansible.builtin.shell: |
-    oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ iib }}" --field-selector "metadata.name={{ item }}" \
+    oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ item.value['iib'] }}" --field-selector "metadata.name={{ item.key }}" \
       -o jsonpath='{.items[0].status.defaultChannel}'
   register: default_channel_raw
   retries: 10
@@ -15,9 +15,13 @@
   ansible.builtin.set_fact:
     default_channel: "{{ default_channel_raw.stdout }}"
 
-- name: Get all related images in the IIB for "{{ item }}"
+- name: Print default channel
+  ansible.builtin.debug:
+    msg: "Default channel for {{ item.key }}: {{ default_channel }}"
+
+- name: Get all related images in the IIB for "{{ item.key }}"
   ansible.builtin.shell: |
-    oc get packagemanifests -l "catalog=iib-{{ iib }}" --field-selector "metadata.name={{ item }}" \
+    oc get packagemanifests -l "catalog=iib-{{ item.value['iib'] }}" --field-selector "metadata.name={{ item.key }}" \
       -o jsonpath="{.items[0].status.channels[?(@.name==\"{{ default_channel }}\")].currentCSVDesc.relatedImages}"
   register: related_images_raw
   retries: 5
@@ -29,7 +33,7 @@
     related_images: "{{ related_images_raw.stdout }}"
 
 # NOTE(bandini)
-# The following code is here to fund out what the operator bundle image is and to make
+# The following code is here to find out what the operator bundle image is and to make
 # sure it is on the internal registry.
 # This is all potentially hacky, but so far I could not find a single place in the cluster
 # where the olm.bundle image is available. The info is in there in the IIB, but it certainly
@@ -37,7 +41,7 @@
 # alpha commands inside the IIB image locally
 - name: Pull the IIB locally
   ansible.builtin.command:
-    podman pull "{{ iib_image }}"
+    podman pull "{{ item.value['iib_image'] }}"
 
 # $ opm alpha list channels /configs advanced-cluster-management
 # PACKAGE                      CHANNEL      HEAD
@@ -46,7 +50,7 @@
 - name: Read the operator bundle from the default channel
   ansible.builtin.shell: |
     set -o pipefail
-    podman run -it --rm "{{ iib_image }}" alpha list channels /configs "{{ item }}" | grep -E "(\s){{ default_channel }}(\s)" | awk '{ print $3 }'
+    podman run -it --rm "{{ item.value['iib_image'] }}" alpha list channels /configs "{{ item.key }}" | grep -E "(\s){{ default_channel }}(\s)" | awk '{ print $3 }'
   register: bundle_channel_raw
 
 - name: Set bundle fact
@@ -70,7 +74,7 @@
 - name: Get bundle image
   ansible.builtin.shell: |
     set -o pipefail
-    podman run -it --rm "{{ iib_image }}" alpha list bundles /configs "{{ item }}" | grep -e "{{ default_channel }}\s\+{{ bundle_channel }}" | awk '{ print $NF }'
+    podman run -it --rm "{{ item.value['iib_image'] }}" alpha list bundles /configs "{{ item.key }}" | grep -e "{{ default_channel }}\s\+{{ bundle_channel }}" | awk '{ print $NF }'
   register: bundle_image_raw
 
 - name: Set bundle image fact

--- a/common/ansible/roles/iib_ci/tasks/install-iib-in-cluster.yml
+++ b/common/ansible/roles/iib_ci/tasks/install-iib-in-cluster.yml
@@ -1,3 +1,7 @@
+- name: Set IIB local folder fact
+  ansible.builtin.set_fact:
+    iib_local_folder: "/tmp/manifest-{{ item.value['iib'] }}"
+
 - name: Remove manifest folder "{{ iib_local_folder }}"
   ansible.builtin.file:
     path: "{{ iib_local_folder }}"
@@ -16,14 +20,14 @@
 - name: Mirror catalog manifests only to "{{ iib_local_folder }}"
   ansible.builtin.shell: |
     oc adm catalog mirror --insecure --manifests-only --to-manifests=. \
-      "{{ iib_image }}" "{{ rh_internal_registry }}/rh-osbs" > catalog.log 2>&1
+      "{{ item.value['iib_image'] }}" "{{ rh_internal_registry }}/rh-osbs" > catalog.log 2>&1
   args:
     chdir: "{{ iib_local_folder }}"
 
 - name: Mirror IIB to "{{ mirror_iib }}"
   ansible.builtin.shell: |
     oc image mirror -a "{{ pull_secrets_tempfolder.path }}/.dockerconfigjson" \
-      "{{ iib_image }}={{ mirror_iib }}" --insecure --keep-manifest-list 2>&1
+      "{{ item.value['iib_image'] }}={{ mirror_iib }}" --insecure --keep-manifest-list 2>&1
   args:
     chdir: "{{ iib_local_folder }}"
   register: oc_mirror_result
@@ -43,7 +47,7 @@
 
 - name: Wait for catalogsource to show up
   ansible.builtin.shell: |
-    oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ iib }}" --field-selector "metadata.name={{ operator }}" \
+    oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ item.value['iib'] }}" --field-selector "metadata.name={{ item.key }}" \
       -o jsonpath='{.items[0].status.defaultChannel}'
   register: oc_catalogsource_result
   retries: 30

--- a/common/ansible/roles/iib_ci/tasks/main.yml
+++ b/common/ansible/roles/iib_ci/tasks/main.yml
@@ -1,9 +1,3 @@
-- name: Check that INDEX_IMAGE env variable is set
-  ansible.builtin.fail:
-    msg: "INDEX_IMAGE: '{{ iib_image }}' is not set"
-  failed_when:
-    (iib_image is not defined or iib_image | length == 0)
-
 - name: Check for pre-requisite binaries presence
   ansible.builtin.shell: |
     which "{{ item }}"
@@ -12,13 +6,11 @@
     - oc
     - podman
 
-- name: Set IIB fact
-  ansible.builtin.set_fact:
-    iib: "{{ iib_image.split(':')[1] }}"
-
-- name: Set IIB local folder fact
-  ansible.builtin.set_fact:
-    iib_local_folder: "/tmp/manifest-{{ iib }}"
+- name: Check that INDEX_IMAGES env variable is set
+  ansible.builtin.fail:
+    msg: "INDEX_IMAGES: '{{ iib_images }}' is not set"
+  failed_when:
+    (iib_images is not defined or iib_images | length == 0)
 
 - name: Get cluster version
   # E.g. 4.13.0-rc.6 or 4.12.16
@@ -36,14 +28,44 @@
     msg: "OCP versions < 4.13 are not support for IIB loading"
   when: not ocp_413
 
+- name: Set images array
+  ansible.builtin.set_fact:
+    iib_image_list: "{{ iib_images.split(',') }}"
+
+- name: Set operator array
+  ansible.builtin.set_fact:
+    operator_list: "{{ operator.split(',') }}"
+
+# Creates a dict like:
+# "advanced-cluster-management": {
+#   "iib": "713808",
+#   "iib_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib:713808"
+# },
+# "multicluster-engine": {
+#   "iib": "713809",
+#   "iib_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib:713809"
+# }
+- name: Set IIB dict
+  ansible.builtin.set_fact:
+    iib_dict: "{{ iib_dict | default({}) | combine({item.0: {'iib_image': item.1, 'iib': item.1.split(':')[-1]}}) }}"
+  with_together:
+    - "{{ operator_list }}"
+    - "{{ iib_image_list }}"
+
+- name: Working with the following IIB data
+  ansible.builtin.debug:
+    msg: "{{ iib_dict }}"
+
 - name: Set up internal registry (OCP >= 4.13)
   ansible.builtin.include_tasks: setup-internal-registry.yml
 
 - name: Install new IIB in cluster
   ansible.builtin.include_tasks: install-iib-in-cluster.yml
+  with_items: "{{ iib_dict | dict2items }}"
 
 - name: Mirror all related images
   ansible.builtin.include_tasks: mirror-related-images.yml
+  with_items: "{{ iib_dict | dict2items }}"
 
 - name: Remove pullsecrets tempfolder
   ansible.builtin.file:

--- a/common/ansible/roles/iib_ci/tasks/mirror-related-images.yml
+++ b/common/ansible/roles/iib_ci/tasks/mirror-related-images.yml
@@ -1,8 +1,7 @@
-# This is needed because some operators like "advanced-cluster-management"
-# install a second operator "multicluster-engine"
-- name: Set operators list
+# We redefine this var so it is easier to run this task independently
+- name: Set IIB local folder fact
   ansible.builtin.set_fact:
-    operator_list: "{{ [operator] + (operator == 'advanced-cluster-management') | ternary(['multicluster-engine'], []) }}"
+    iib_local_folder: "/tmp/manifest-{{ item.value['iib'] }}"
 
 - name: Set all images to empty list
   ansible.builtin.set_fact:
@@ -10,7 +9,6 @@
 
 - name: Fetch operator images tasks
   ansible.builtin.include_tasks: fetch-operator-images.yml
-  loop: "{{ operator_list }}"
 
 - name: Print all_images
   ansible.builtin.debug:
@@ -119,7 +117,7 @@
   ansible.builtin.debug:
     msg: "{{ image_urls }}"
 
-# OCP 4.13 uses the new fangled "ImageDigestMirrorSet", older OCPs use "ImageContentSourcePolicy"
+# OCP 4.13 uses the new fangled "ImageDigestMirrorSet"
 - name: Template out imageMirror.yaml (OCP >= 4.13)
   ansible.builtin.template:
     src: ./templates/imageDigestMirror.yaml.j2

--- a/common/ansible/roles/iib_ci/templates/catalogSource.yaml.j2
+++ b/common/ansible/roles/iib_ci/templates/catalogSource.yaml.j2
@@ -1,9 +1,9 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: iib-{{ iib }}
+  name: iib-{{ item.value['iib'] }}
   namespace: {{ internal_registry_ns }}
 spec:
-  image: {{ mirror_iib }}:{{ iib }}
+  image: {{ mirror_iib }}:{{ item.value['iib'] }}
   sourceType: grpc
-  displayName: IIB {{ iib }}
+  displayName: IIB {{ item.value['iib'] }}

--- a/common/ansible/roles/iib_ci/templates/imageDigestMirror.yaml.j2
+++ b/common/ansible/roles/iib_ci/templates/imageDigestMirror.yaml.j2
@@ -3,16 +3,16 @@ kind: ImageDigestMirrorSet
 metadata:
   labels:
     operators.openshift.org/catalog: "true"
-  name: iib-{{ iib }}
+  name: iib-{{ item.value['iib'] }}
 spec:
   imageDigestMirrors:
-{% for item in image_urls.values() %}
+{% for data in image_urls.values() %}
     - mirrors:
-        - {{ item.mirrordest_nosha }}
-      source: {{ item.source_nosha }}
+        - {{ data.mirrordest_nosha }}
+      source: {{ data.source_nosha }}
       mirrorSourcePolicy: AllowContactingSource
     - mirrors:
-        - {{ item.mirrordest_nosha }}
-      source: {{ item.image_nosha }}
+        - {{ data.mirrordest_nosha }}
+      source: {{ data.image_nosha }}
       mirrorSourcePolicy: AllowContactingSource
 {% endfor %}


### PR DESCRIPTION
This adds multiple IIB support in order to cater for the ACM IIB case,
where the MCE operator might be in another IIB completely.

To load multiple IIB for different operators, one needs to set the env
variables as follows:

    export OPERATOR=advanced-cluster-management,multicluster-engine
    export INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:713808,registry-proxy.engineering.redhat.com/rh-osbs/iib:718034

It is implied that the first IIB is for the first operator in the list,
and the second one for the latter.

Tested gitops-iib and it all worked with no changes.
