### PR TITLE
Update argocd app check for edge site, get managed site name from kubeconfig

### DIFF
--- a/tests/interop/test_validate_hub_site_components.py
+++ b/tests/interop/test_validate_hub_site_components.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import pytest
+import yaml
 from ocp_resources.route import Route
 from ocp_resources.storage_class import StorageClass
 from validatedpatterns_tests.interop import components


### PR DESCRIPTION
Get resources for failed argocd apps.
Check kubeconfig file for managed site name.