### PR TITLE
common automatic update

### DIFF
--- a/common/.github/workflows/chart-branches.yml
+++ b/common/.github/workflows/chart-branches.yml
@@ -49,9 +49,7 @@ jobs:
 
   acm:
     needs: changes
-    if: |
-      ${{ needs.changes.outputs.acm == 'true' }} &&
-      github.repository == 'validatedpatterns/common'
+    if: ${{ (needs.changes.outputs.acm == 'true') && (github.repository == 'validatedpatterns/common') }}
     uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
     permissions:
       actions: write
@@ -63,9 +61,7 @@ jobs:
 
   golang-external-secrets:
     needs: changes
-    if: |
-      ${{ needs.changes.outputs.golang-external-secrets == 'true' }} &&
-      github.repository == 'validatedpatterns/common'
+    if: ${{ (needs.changes.outputs.golang-external-secrets == 'true') && (github.repository == 'validatedpatterns/common') }}
     uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
     permissions:
       actions: write
@@ -77,9 +73,7 @@ jobs:
 
   hashicorp-vault:
     needs: changes
-    if: |
-      ${{ needs.changes.outputs.hashicorp-vault == 'true' }} &&
-      github.repository == 'validatedpatterns/common'
+    if: ${{ (needs.changes.outputs.hashicorp-vault == 'true') && (github.repository == 'validatedpatterns/common') }}
     uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
     permissions:
       actions: write
@@ -91,9 +85,7 @@ jobs:
 
   letsencrypt:
     needs: changes
-    if: |
-      ${{ needs.changes.outputs.letsencrypt == 'true' }} &&
-      github.repository == 'validatedpatterns/common'
+    if: ${{ (needs.changes.outputs.letsencrypt == 'true') && (github.repository == 'validatedpatterns/common') }}
     uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
     permissions:
       actions: write
@@ -105,9 +97,7 @@ jobs:
 
   clustergroup:
     needs: changes
-    if: |
-      ${{ needs.changes.outputs.clustergroup == 'true' }} &&
-      github.repository == 'validatedpatterns/common'
+    if: ${{ (needs.changes.outputs.clustergroup == 'true') && (github.repository == 'validatedpatterns/common') }}
     uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
     permissions:
       actions: write

--- a/common/.github/workflows/chart-split.yml
+++ b/common/.github/workflows/chart-split.yml
@@ -31,8 +31,12 @@ jobs:
           set -e
           N="${{ inputs.chart_name }}"
           B="${N}-main-single-chart"
+          GITIMG="quay.io/hybridcloudpatterns/gitsubtree-container:2.40.1"
+          sudo apt-get update -y && sudo apt-get install -y podman
+          echo "Running subtree split for ${B}"
+          podman pull "${GITIMG}"
           git push origin -d "${B}" || /bin/true
-          git subtree split -P "${N}" -b "${B}"
-          git push -f -u origin "${B}"
+          # Git subtree got broken on recent versions of git hence this container
+          podman run --net=host --rm -t -v .:/git "${GITIMG}" subtree split -P "${N}" -b "${B}"
           #git clone https://validatedpatterns:${GITHUB_TOKEN}@github.com/validatedpatterns/common.git -b "acm-main-single-chart" --single-branch
           git push --force https://validatedpatterns:"${GITHUB_TOKEN}"@github.com/${{ inputs.target_repository }}.git "${B}:main"

--- a/common/.github/workflows/superlinter.yml
+++ b/common/.github/workflows/superlinter.yml
@@ -21,7 +21,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@v5
+        uses: github/super-linter/slim@v6
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -29,8 +29,11 @@ jobs:
           # These are the validation we disable atm
           VALIDATE_ANSIBLE: false
           VALIDATE_BASH: false
+          VALIDATE_CHECKOV: false
           VALIDATE_JSCPD: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
+          VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_SHELL_SHFMT: false
           VALIDATE_YAML: false
           # VALIDATE_DOCKERFILE_HADOLINT: false
           # VALIDATE_MARKDOWN: false

--- a/common/Makefile
+++ b/common/Makefile
@@ -230,17 +230,20 @@ kubeconform: ## run helm kubeconform
 super-linter: ## Runs super linter locally
 	rm -rf .mypy_cache
 	podman run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true	\
+					-e VALIDATE_ANSIBLE=false \
 					-e VALIDATE_BASH=false \
+					-e VALIDATE_CHECKOV=false \
+					-e VALIDATE_DOCKERFILE_HADOLINT=false \
 					-e VALIDATE_JSCPD=false \
 					-e VALIDATE_KUBERNETES_KUBECONFORM=false \
-					-e VALIDATE_YAML=false \
-					-e VALIDATE_ANSIBLE=false \
-					-e VALIDATE_DOCKERFILE_HADOLINT=false \
+					-e VALIDATE_PYTHON_PYLINT=false \
+					-e VALIDATE_SHELL_SHFMT=false \
 					-e VALIDATE_TEKTON=false \
+					-e VALIDATE_YAML=false \
 					$(DISABLE_LINTERS) \
 					-v $(PWD):/tmp/lint:rw,z \
 					-w /tmp/lint \
-					docker.io/github/super-linter:slim-v5
+					ghcr.io/super-linter/super-linter:slim-v6
 
 .PHONY: ansible-lint
 ansible-lint: ## run ansible lint on ansible/ folder

--- a/common/acm/README.md
+++ b/common/acm/README.md
@@ -1,0 +1,5 @@
+# Validated Patterns ACM chart
+
+This chart is used to set up ACM in [Validated Patterns](https://validatedpatterns.io)
+
+Please send PRs [here](https://github.com/validatedpatterns/common)

--- a/common/acm/templates/provision/clusterdeployment.yaml
+++ b/common/acm/templates/provision/clusterdeployment.yaml
@@ -1,0 +1,83 @@
+{{- range .Values.clusterGroup.managedClusterGroups }}
+{{- $group := . }}
+
+{{- range $group.clusterDeployments}}
+{{ $cluster := . }}
+
+{{- if (eq $cluster.name nil) }}
+{{- fail (printf "managedClusterGroup clusterDeployment cluster name is empty: %s" $cluster) }}
+{{- end }}
+{{- if (eq $group.name nil) }}
+{{- fail (printf "managedClusterGroup clusterDeployment group name is empty: %s" $cluster) }}
+{{- end }}
+
+{{- $deploymentName := print $cluster.name "-" $group.name }}
+
+{{- $cloud := "None" }}
+{{- $region := "None" }}
+
+{{- if $cluster.platform.aws }}
+{{- $cloud = "aws" }}
+{{- $region = $cluster.platform.aws.region }}
+{{- else if $cluster.platform.azure }}
+{{- $cloud = "azure" }}
+{{- $region = $cluster.platform.azure.region }}
+{{- end }}
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $deploymentName }}
+
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: {{ $deploymentName }}
+  namespace: {{ $deploymentName }}
+  labels:
+    vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  baseDomain: {{ $cluster.baseDomain }}
+  clusterName: {{ $deploymentName }}
+  installAttemptsLimit: 1
+  platform:
+    {{ $cloud }}:
+      credentialsSecretRef:
+        name: {{ $deploymentName }}-creds
+      region: {{ $region }}
+  provisioning:
+    installConfigSecretRef:
+      name: {{ $deploymentName }}-install-config
+    sshPrivateKeySecretRef:
+      name: {{ $deploymentName }}-ssh-private-key
+    imageSetRef:
+      name: img{{ $cluster.openshiftVersion }}-multi-appsub
+  pullSecretRef:
+    name: {{ $deploymentName }}-pull-secret
+
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: {{ $group.name }}
+  {{- if (not $group.acmlabels) }}
+    clusterGroup: {{ $group.name }}
+  {{- else if eq (len $group.acmlabels) 0 }}
+    clusterGroup: {{ $group.name }}
+  {{- else }}
+    {{- range $group.acmlabels }}
+    {{ .name }}: {{ .value }}
+    {{- end }}
+  {{- end }}
+  name: {{ $deploymentName }}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubAcceptsClient: true
+{{- end }}{{- /* range $group.clusterDeployments */}}
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/common/acm/templates/provision/clusterpool.yaml
+++ b/common/acm/templates/provision/clusterpool.yaml
@@ -1,17 +1,5 @@
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
-{{- if .clusterPools }}{{- /* We only create ManagedClusterSets if there are clusterPools defined */}}
-apiVersion: cluster.open-cluster-management.io/v1beta1
-kind: ManagedClusterSet
-metadata:
-  annotations:
-    cluster.open-cluster-management.io/submariner-broker-ns: {{ .name }}-broker
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  name: {{ .name }}
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
----
 {{- range .clusterPools }}
 
 {{- $pool := . }}
@@ -54,7 +42,7 @@ spec:
   runningCount: {{ $numClusters }}
   baseDomain: {{ .baseDomain }}
   installConfigSecretTemplateRef:
-    name: {{ $poolName }}-install-config 
+    name: {{ $poolName }}-install-config
   imageSetRef:
     name: img{{ .openshiftVersion }}-multi-appsub
   pullSecretRef:
@@ -91,5 +79,4 @@ spec:
 ---
 {{- end }}{{- /* range .range clusters */}}
 {{- end }}{{- /* range .clusterPools */}}
-{{- end }}{{- /* if .clusterPools) */}}
 {{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/common/acm/templates/provision/managedclusterset.yaml
+++ b/common/acm/templates/provision/managedclusterset.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.clusterGroup.managedClusterGroups }}
+{{- if or .clusterPools .clusterDeployments }}{{- /* We only create ManagedClusterSets if there are clusterPools or clusterDeployments defined */}}
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  annotations:
+    cluster.open-cluster-management.io/submariner-broker-ns: {{ .name }}-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: {{ .name }}
+
+{{- end }}{{- /* if .clusterPools) */}}
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/common/acm/templates/provision/secrets-aws.yaml
+++ b/common/acm/templates/provision/secrets-aws.yaml
@@ -3,58 +3,88 @@
 {{- range .clusterPools }}
 {{- $poolName := print .name "-" $group.name }}
 {{- if .platform.aws }}
+---
+{{- template "externalsecret.aws.creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.aws.infra-creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+
+{{- end }}{{- /* if .platform.aws */}}
+{{- end }}{{- /* range .clusterPools  */}}
+
+{{- range .clusterDeployments }}
+{{- $deploymentName := print .name "-" $group.name }}
+{{- if .platform.aws }}
+---
+{{- template "externalsecret.aws.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
+---
+{{- template "externalsecret.aws.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
+
+{{- end }}{{- /* if .platform.aws */}}
+{{- end }}{{- /* range .clusterDeployments  */}}
+
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}
+
+{{- define "externalsecret.aws.creds" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-creds
+  name: {{ .name }}-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   dataFrom:
   - extract:
       # Expects entries called: aws_access_key_id and aws_secret_access_key
-      key: {{ default "secret/data/hub/aws" .awsKeyPath }}
+      key: {{ default "secret/data/hub/aws" .context.awsKeyPath }}
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-creds
+    name: {{ .name }}-creds
     creationPolicy: Owner
     template:
       type: Opaque
----
+{{- end}}
+
+{{- define "externalsecret.aws.infra-creds"}}
 # For use when manually creating clusters with ACM
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-infra-creds
-spec: 
+  name: {{ .name }}-infra-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
-      key: {{ default "secret/data/hub/openshiftPullSecret" .pullSecretKeyPath }}
+      key: {{ default "secret/data/hub/openshiftPullSecret" .context.pullSecretKeyPath }}
       property: content
   - secretKey: awsKeyId
     remoteRef:
-      key: {{ default "secret/data/hub/aws" .awsKeyPath }}
+      key: {{ default "secret/data/hub/aws" .context.awsKeyPath }}
       property: aws_access_key_id
   - secretKey: awsAccessKey
     remoteRef:
-      key: {{ default "secret/data/hub/aws" .awsKeyPath }}
+      key: {{ default "secret/data/hub/aws" .context.awsKeyPath }}
       property: aws_secret_access_key
   - secretKey: sshPublicKey
     remoteRef:
-      key: {{ default "secret/data/hub/publickey" .sshPublicKeyPath }}
+      key: {{ default "secret/data/hub/publickey" .context.sshPublicKeyPath }}
       property: content
   - secretKey: sshPrivateKey
     remoteRef:
-      key: {{ default "secret/data/hub/privatekey" .sshPrivateKeyPath }}
+      key: {{ default "secret/data/hub/privatekey" .context.sshPrivateKeyPath }}
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+  secretStoreRef:
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-infra-creds
+    name: {{ .name }}-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -63,7 +93,7 @@ spec:
           cluster.open-cluster-management.io/credentials: ""
           cluster.open-cluster-management.io/type: aws
       data:
-        baseDomain: "{{ .baseDomain }}"
+        baseDomain: "{{ .context.baseDomain }}"
         pullSecret: |-
           {{ "{{ .openshiftPullSecret | toString }}" }}
         aws_access_key_id: |-
@@ -78,7 +108,4 @@ spec:
         httpsProxy: ""
         noProxy: ""
         additionalTrustBundle: ""
----
-{{- end }}
-{{- end }}
-{{- end }}
+{{- end}}

--- a/common/acm/templates/provision/secrets-azure.yaml
+++ b/common/acm/templates/provision/secrets-azure.yaml
@@ -3,58 +3,90 @@
 {{- range .clusterPools }}
 {{- $poolName := print .name "-" $group.name }}
 {{- if .platform.azure }}
+---
+{{- template "externalsecret.azure.creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.azure.infra-creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+
+---
+{{- end }}{{- /* if .platform.azure */}}
+{{- end }}{{- /* range .clusterPools  */}}
+
+{{- range .clusterDeployments }}
+{{- $deploymentName := print .name "-" $group.name }}
+{{- if .platform.azure }}
+---
+{{- template "externalsecret.azure.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
+---
+{{- template "externalsecret.azure.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
+
+
+{{- end }}{{- /* if .platform.azure */}}
+{{- end }}{{- /* range .clusterPools  */}}
+
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups  */}}
+
+{{- define "externalsecret.azure.creds" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-creds
+  name: {{ .name }}-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: azureOsServicePrincipal
     remoteRef:
-      key: {{ default "secret/data/hub/azureOsServicePrincipal" .azureKeyPath }}
+      key: {{ default "secret/data/hub/azureOsServicePrincipal" .context.azureKeyPath }}
       property: content
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-creds
+    name: {{ .name }}-creds
     creationPolicy: Owner
     template:
       type: Opaque
       data:
         osServicePrincipal.json: |-
           {{ "{{ .azureOsServicePrincipal | toString }}" }}
----
+{{- end }}
+
+{{- define "externalsecret.azure.infra-creds"}}
 # For use when manually creating clusters with ACM
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-infra-creds
-spec: 
+  name: {{ .name }}-infra-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
-      key: {{ default "secret/data/hub/openshiftPullSecret" .pullSecretKeyPath }}
+      key: {{ default "secret/data/hub/openshiftPullSecret" .context.pullSecretKeyPath }}
       property: content
   - secretKey: sshPublicKey
     remoteRef:
-      key: {{ default "secret/data/hub/publickey" .sshPublicKeyPath }}
+      key: {{ default "secret/data/hub/publickey" .context.sshPublicKeyPath }}
       property: content
   - secretKey: sshPrivateKey
     remoteRef:
-      key: {{ default "secret/data/hub/privatekey" .sshPrivateKeyPath }}
+      key: {{ default "secret/data/hub/privatekey" .context.sshPrivateKeyPath }}
       property: content
   - secretKey: azureOsServicePrincipal
     remoteRef:
-      key: {{ default "secret/data/hub/azureOsServicePrincipal" .azureKeyPath }}
+      key: {{ default "secret/data/hub/azureOsServicePrincipal" .context.azureKeyPath }}
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+  secretStoreRef:
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-infra-creds
+    name: {{ .name }}-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -66,8 +98,8 @@ spec:
         cloudName: AzurePublicCloud
         osServicePrincipal.json: |-
           {{ "{{ .azureOsServicePrincipal | toString }}" }}
-        baseDomain: "{{ .baseDomain }}"
-        baseDomainResourceGroupName: "{{ .platform.azure.baseDomainResourceGroupName | toString }}"
+        baseDomain: "{{ .context.baseDomain }}"
+        baseDomainResourceGroupName: "{{ .context.platform.azure.baseDomainResourceGroupName | toString }}"
         pullSecret: |-
           {{ "{{ .openshiftPullSecret | toString }}" }}
         ssh-privatekey: |-
@@ -78,7 +110,4 @@ spec:
         httpsProxy: ""
         noProxy: ""
         additionalTrustBundle: ""
----
-{{- end }}
-{{- end }}
 {{- end }}

--- a/common/acm/templates/provision/secrets-common.yaml
+++ b/common/acm/templates/provision/secrets-common.yaml
@@ -1,61 +1,95 @@
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
+
 {{- range .clusterPools }}
 {{- $poolName := print .name "-" $group.name }}
+---
+{{- template "secret.install-config" (dict "name" $poolName "context" .) }}
+---
+{{- template "externalsecret.pull-secret" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.ssh.private.key" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+{{- end }}{{- /* range .clusterPools */}}
+
+{{- range .clusterDeployments }}
+{{- $deploymentName := print .name "-" $group.name }}
+---
+{{- template "secret.install-config" (dict "name" $deploymentName "context" . "namespaced" true) }}
+---
+{{- template "externalsecret.pull-secret" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
+---
+{{- template "externalsecret.ssh.private.key" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
+{{- end }}{{- /* range .clusterDeplyments */}}
+
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}
+
+{{- define "secret.install-config"}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $poolName }}-install-config
+  name: {{ .name }}-install-config
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: {{ include "cluster.install-config" . | b64enc }} 
+  install-config.yaml: {{ include "cluster.install-config" .context | b64enc }}
 type: Opaque
----
+{{- end }}
+
+{{- define "externalsecret.pull-secret" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-pull-secret
-spec: 
+  name: {{ .name }}-pull-secret
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
-      key: {{ default "secret/data/hub/openshiftPullSecret" .pullSecretKeyPath }}
+      key: {{ default "secret/data/hub/openshiftPullSecret" .context.pullSecretKeyPath }}
       property: content
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-pull-secret
+    name: {{ .name }}-pull-secret
     creationPolicy: Owner
     template:
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: |-
           {{ "{{ .openshiftPullSecret | toString }}" }}
----
+{{- end }}
+
+
+{{- define "externalsecret.ssh.private.key" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-ssh-private-key
+  name: {{ .name }}-ssh-private-key
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: sshPrivateKey
     remoteRef:
-      key: {{ default "secret/data/hub/privatekey" .sshPrivateKeyPath }}
+      key: {{ default "secret/data/hub/privatekey" .context.sshPrivateKeyPath }}
       property: content
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-ssh-private-key
+    name: {{ .name }}-ssh-private-key
     creationPolicy: Owner
     template:
       type: Opaque
       data:
         ssh-privatekey: |-
           {{ "{{ .sshPrivateKey | toString }}" }}
----
-{{- end }}
 {{- end }}

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -23,14 +23,29 @@ clusterGroup:
 #        testPool:
 #          name: spoke
 #          openshiftVersion: 4.10.18
-#          provider:
-#            region: ap-southeast-2
-#            baseDomain: blueprints.rhecoeng.com
+#          baseDomain: blueprints.rhecoeng.com
+#          platform:
+#            aws:
+#              region: ap-southeast-2
 #          clusters:
 #          - spoke1
 #      labels:
 #      - name: clusterGroup
 #        value: region-one
+#    testRegionTwo:
+#      name: region-two
+#      clusterDeployments:
+#        myFirstCluster:
+#          name: mcluster1
+#          openshiftVersion: 4.10.18
+#          baseDomain: blueprints.rhecoeng.com
+#          platform:
+#            azure:
+#              baseDomainResourceGroupName: dojo-dns-zones
+#              region: eastus
+#      labels:
+#        - name: clusterGroup
+#          value: region-two
 
 acm:
   # Just used for IIB testing, drives the source and channel for the MCE

--- a/common/ansible/playbooks/auto-approve-installplans/auto-approve-installplans.yaml
+++ b/common/ansible/playbooks/auto-approve-installplans/auto-approve-installplans.yaml
@@ -1,0 +1,40 @@
+# This playbook will watch for pending install plans of managed operators
+# if they are in Manual and there's a startingCSV that must be installed
+---
+- name: InstallPlan Auto-Approver
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+
+  tasks:
+  - name: Get all installPlans from OpenShift
+    kubernetes.core.k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: InstallPlan
+    register: installplans
+
+  - name: Get required CSVs from clusterGroup data
+    ansible.builtin.set_fact:
+      expected_csv: "{{ expected_csv | default([]) + [item.csv] }}"
+    when: item.csv | default(false) and
+          ((item.installPlanApproval | default("") == "Manual") or
+          (item.installPlanApproval | default("") == "" and global.options.installPlanApproval | default("") == "Manual"))
+    with_items: "{{ clusterGroup.subscriptions.values() }}"
+
+  # TODO: loop over clusterGroup.subscriptions instead of installplans
+  #       to allow certain control on the order of approvals
+  # IDEA: allow adding a per-installplan delay after the approval before
+  #       moving forward to the next one
+  - name: Approve the missing installPlans
+    kubernetes.core.k8s_json_patch:
+      api_version: operators.coreos.com/v1alpha1
+      kind: InstallPlan
+      name: "{{ item.metadata.name }}"
+      namespace: "{{ item.metadata.namespace }}"
+      patch:
+      - op: replace
+        path: /spec/approved
+        value: true
+    when: (item.spec.clusterServiceVersionNames | intersect(expected_csv | default([]))) | length > 0
+    loop: "{{ installplans.resources }}"

--- a/common/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/common/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -72,6 +72,11 @@
     api_version: v1
     validate_certs: "{{ validate_certs_api_endpoint }}"
   register: remote_external_secrets_sa
+  # We are allowed to ignore errors here because a spoke might be down or unreachable
+  # if a spoke is not reachable then its ['token'] field will not be set which
+  # will leave the ['esoToken'] field empty in the dict which will make it so that
+  # the spoke gets skipped
+  ignore_errors: true
   when:
     - clusters_info[item.key]['bearerToken'] is defined
     - clusters_info[item.key]['server_api'] is defined

--- a/common/clustergroup/Chart.yaml
+++ b/common/clustergroup/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart to create per-clustergroup ArgoCD applications and any
 keywords:
 - pattern
 name: clustergroup
-version: 0.8.5
+version: 0.8.6

--- a/common/clustergroup/README.md
+++ b/common/clustergroup/README.md
@@ -1,0 +1,5 @@
+# Validated Patterns ClusterGroup chart
+
+This chart is used to set up the basic building blocks in [Validated Patterns](https://validatedpatterns.io)
+
+Please send PRs [here](https://github.com/validatedpatterns/common)

--- a/common/clustergroup/templates/core/scheduler.yaml
+++ b/common/clustergroup/templates/core/scheduler.yaml
@@ -1,0 +1,11 @@
+{{- if not (eq .Values.enabled "plumbing") }}
+{{- if hasKey .Values.clusterGroup "scheduler" }}
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+{{- toYaml .Values.clusterGroup.scheduler | nindent 2 }}
+{{- end -}}
+{{- end -}}
+

--- a/common/clustergroup/templates/imperative/auto-approve-installplans.yaml
+++ b/common/clustergroup/templates/imperative/auto-approve-installplans.yaml
@@ -1,0 +1,52 @@
+{{- if $.Values.global.options.autoApproveManualInstallPlans }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: auto-approve-installplans-cronjob
+  namespace: {{ $.Values.clusterGroup.imperative.namespace}}
+spec:
+  schedule: "*/5 * * * *"
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ $.Values.clusterGroup.imperative.activeDeadlineSeconds }}
+      template:
+        metadata:
+          name: auto-approve-installplans-job
+        spec:
+          serviceAccountName: {{ $.Values.clusterGroup.imperative.adminServiceAccountName }}
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there
+            {{- include  "imperative.initcontainers.gitinit" . | indent 12 }}
+            - name: auto-approve-installplans
+              image: {{ $.Values.clusterGroup.imperative.image }}
+              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+              env:
+              - name: HOME
+                value: /git/home
+              workingDir: /git/repo
+              command:
+              - timeout
+              - {{ .timeout | default "600" | quote }}
+              - ansible-playbook
+              {{- if $.Values.clusterGroup.imperative.verbosity }}
+              - {{ $.Values.clusterGroup.imperative.verbosity }}
+              {{- end }}
+              - -e
+              - "@/values/values.yaml"
+              - common/ansible/playbooks/auto-approve-installplans/auto-approve-installplans.yaml
+              volumeMounts:
+                {{- include "imperative.volumemounts" . | indent 16 }}
+          containers:
+          {{- include "imperative.containers.done" . | indent 12 }}
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: {{ $.Values.clusterGroup.imperative.valuesConfigMap }}-{{ $.Values.clusterGroup.name }}
+          restartPolicy: Never
+{{- end }}

--- a/common/clustergroup/values.schema.json
+++ b/common/clustergroup/values.schema.json
@@ -230,6 +230,10 @@
           "deprecated": true,
           "description": "This is used to approval strategy for the subscriptions of OpenShift Operators being installed. You can choose Automatic or Manual updates. NOTE: This setting is now available in the subcriptions description in the values file."
         },
+        "autoApproveManualInstallPlans": {
+          "type": "boolean",
+          "description": "This is used to approve automatically those subscriptions of OpenShift Operators that are in Manual with a startingCSV version. You can choose True or False. Defaults: False."
+        },
         "applicationRetryLimit": {
           "type": "integer",
           "description": "Number of failed sync attempt retries; unlimited number of attempts if less than 0"
@@ -261,6 +265,10 @@
             "type": "array",
             "description": "Templated value file paths."
 	},
+        "scheduler": {
+          "type": "object",
+          "description": "If set, it will become the spec of the scheduler/cluster in the managed cluster."
+        },
         "namespaces": {
           "anyOf": [
             {
@@ -758,6 +766,12 @@
             "$ref": "#/definitions/ClusterPools"
           }
         },
+        "clusterDeployments": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/ClusterDeployments"
+          }
+        },
         "clusterSelector": {
           "type": "object",
           "additionalProperties": true
@@ -804,6 +818,32 @@
         "clusters"
       ],
       "title": "ClusterPools"
+    },
+    "ClusterDeployments": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "openshiftVersion": {
+          "type": "string"
+        },
+        "baseDomain": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "object",
+          "$ref": "#/definitions/ClusterPoolsPlatform"
+        }
+      },
+      "required": [
+        "name",
+        "openshiftVersion",
+        "baseDomain",
+        "platform"
+      ],
+      "title": "ClusterDeployments"
     },
     "ClusterPoolsPlatform": {
       "type": "object",

--- a/common/clustergroup/values.yaml
+++ b/common/clustergroup/values.yaml
@@ -20,6 +20,11 @@ clusterGroup:
   targetCluster: in-cluster
   sharedValueFiles: []
 
+#  scheduler:
+#    mastersSchedulable: true
+#    defaultNodeSelector: type=user-node,region=east
+#    profile: HighNodeUtilization 
+
   argoCD:
     initContainers: []
     configManagementPlugins: []

--- a/common/examples/values-example.yaml
+++ b/common/examples/values-example.yaml
@@ -15,7 +15,9 @@ clusterGroup:
   - /values/{{ .Values.global.clusterPlatform }}.yaml
   - /values/{{ .Values.global.clusterVersion }}.yaml
 
-  # 
+  scheduler:
+    mastersSchedulable: true
+
   # You can define namespaces using hashes and not as a list like so:
   # namespaces:
   #   open-cluster-management:
@@ -25,7 +27,7 @@ clusterGroup:
   #     annotations:
   #       openshift.io/cluster-monitoring: "true"
   #       owner: "namespace owner"
-  #   application-ci: 
+  #   application-ci:
   # You cannot mix list and hashes to define namespaces
   namespaces:
   - open-cluster-management:
@@ -70,7 +72,7 @@ clusterGroup:
       name: openshift-pipelines-operator-rh
       csv: redhat-openshift-pipelines.v1.5.2
 
-  # 
+  #
   # You can define projects using hashes like so:
   # projects:
   #   hub:
@@ -159,9 +161,26 @@ clusterGroup:
         clusters:
         - Two
         - three
+    clusterDeployments:
+      myFirstCluster:
+        name: aws-cd-one-w-pool
+        openshiftVersion: 4.10.18
+        baseDomain: blueprints.rhecoeng.com
+        platform:
+          aws:
+            region: ap-southeast-1
     acmlabels:
     - name: clusterGroup
       value: region
+  - name: acm-provision-on-deploy
+    clusterDeployments:
+      mySecondCluster:
+        name: aws-cd-two-wo-pool
+        openshiftVersion: 4.10.18
+        baseDomain: blueprints.rhecoeng.com
+        platform:
+          aws:
+            region: ap-southeast-3
   - name: argo-edge
     hostedArgoSites:
     - name: perth

--- a/common/golang-external-secrets/README.md
+++ b/common/golang-external-secrets/README.md
@@ -12,3 +12,7 @@ we just override the tag with the version + "-ubi"
 4. Tweak `values.yaml` with the new image versions
 5. Run `make test`
 6. Commit to git
+
+## PRs
+
+Please send PRs [here](https://github.com/validatedpatterns/common)

--- a/common/hashicorp-vault/README.md
+++ b/common/hashicorp-vault/README.md
@@ -1,5 +1,9 @@
 # VP hashicorp-vault
 
+## PRs
+
+Please send PRs [here](https://github.com/validatedpatterns/common)
+
 ## Updating the chart
 
 1. Edit Chart.yaml with the new version

--- a/common/letsencrypt/README.md
+++ b/common/letsencrypt/README.md
@@ -22,6 +22,10 @@ In order to enable this chart in your patterns, please add and edit the followin
 
 Once the above is enabled in a pattern, a certain amount of time (~15/20 minutes or so) is needed for all the cluster operators to settle, all the HTTPS routes will have a wildcard certificate signed by letsencrypt. By default also the API endpoint will use a certificate signed by letsencrypt.
 
+## PRs
+
+Please send PRs [here](https://github.com/validatedpatterns/common)
+
 ## Limitations
 
 Please be aware of the following gotchas when using this chart:

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+---
 # Source: acm/templates/provision/secrets-common.yaml
 apiVersion: v1
 kind: Secret
@@ -6,7 +18,7 @@ metadata:
   name: aws-ap-acm-provision-edge-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWFwJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAxCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDAKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTIKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz 
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWFwJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAxCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDAKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTIKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
 type: Opaque
 ---
 # Source: acm/templates/provision/secrets-common.yaml
@@ -16,7 +28,29 @@ metadata:
   name: azure-us-acm-provision-edge-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw== 
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
+type: Opaque
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-install-config
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+data:
+  # Base64 encoding of install-config yaml
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLW9uZS13LXBvb2wnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCmNvbXB1dGU6Ci0gaHlwZXJ0aHJlYWRpbmc6IEVuYWJsZWQKICBhcmNoaXRlY3R1cmU6IGFtZDY0CiAgbmFtZTogJ3dvcmtlcicKICByZXBsaWNhczogMwogIHBsYXRmb3JtOgogICAgYXdzOgogICAgICB0eXBlOiBtNS54bGFyZ2UKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTEKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
+type: Opaque
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+data:
+  # Base64 encoding of install-config yaml
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLXR3by13by1wb29sJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhd3M6CiAgICByZWdpb246IGFwLXNvdXRoZWFzdC0zCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
 type: Opaque
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
@@ -61,6 +95,64 @@ metadata:
 spec:
   clusterPoolName: azure-us-acm-provision-edge
 ---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+  labels:
+    vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  baseDomain: blueprints.rhecoeng.com
+  clusterName: aws-cd-one-w-pool-acm-provision-edge
+  installAttemptsLimit: 1
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws-cd-one-w-pool-acm-provision-edge-creds
+      region: ap-southeast-1
+  provisioning:
+    installConfigSecretRef:
+      name: aws-cd-one-w-pool-acm-provision-edge-install-config
+    sshPrivateKeySecretRef:
+      name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+    imageSetRef:
+      name: img4.10.18-multi-appsub
+  pullSecretRef:
+    name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+  labels:
+    vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  baseDomain: blueprints.rhecoeng.com
+  clusterName: aws-cd-two-wo-pool-acm-provision-on-deploy
+  installAttemptsLimit: 1
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+      region: ap-southeast-3
+  provisioning:
+    installConfigSecretRef:
+      name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+    sshPrivateKeySecretRef:
+      name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+    imageSetRef:
+      name: img4.10.18-multi-appsub
+  pullSecretRef:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+---
 # Source: acm/templates/provision/clusterpool.yaml
 apiVersion: hive.openshift.io/v1
 kind: ClusterPool
@@ -79,7 +171,7 @@ spec:
   runningCount: 0
   baseDomain: blueprints.rhecoeng.com
   installConfigSecretTemplateRef:
-    name: aws-ap-acm-provision-edge-install-config 
+    name: aws-ap-acm-provision-edge-install-config
   imageSetRef:
     name: img4.10.18-multi-appsub
   pullSecretRef:
@@ -109,7 +201,7 @@ spec:
   runningCount: 2
   baseDomain: blueprints.rhecoeng.com
   installConfigSecretTemplateRef:
-    name: azure-us-acm-provision-edge-install-config 
+    name: azure-us-acm-provision-edge-install-config
   imageSetRef:
     name: img4.10.18-multi-appsub
   pullSecretRef:
@@ -147,7 +239,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-ap-acm-provision-edge-infra-creds
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -170,11 +262,171 @@ spec:
       key: secret/data/hub/privatekey
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
+  secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore
   target:
     name: aws-ap-acm-provision-edge-infra-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cluster.open-cluster-management.io/credentials: ""
+          cluster.open-cluster-management.io/type: aws
+      data:
+        baseDomain: "blueprints.rhecoeng.com"
+        pullSecret: |-
+          {{ .openshiftPullSecret | toString }}
+        aws_access_key_id: |-
+          {{ .awsKeyId | toString }}
+        aws_secret_access_key: |-
+          {{ .awsAccessKey | toString }}
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+        ssh-publickey: |-
+          {{ .sshPublicKey | toString }}
+        httpProxy: ""
+        httpsProxy: ""
+        noProxy: ""
+        additionalTrustBundle: ""
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-creds
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  dataFrom:
+  - extract:
+      # Expects entries called: aws_access_key_id and aws_secret_access_key
+      key: secret/data/hub/aws
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+# For use when manually creating clusters with ACM
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  - secretKey: awsKeyId
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_access_key_id
+  - secretKey: awsAccessKey
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_secret_access_key
+  - secretKey: sshPublicKey
+    remoteRef:
+      key: secret/data/hub/publickey
+      property: content
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cluster.open-cluster-management.io/credentials: ""
+          cluster.open-cluster-management.io/type: aws
+      data:
+        baseDomain: "blueprints.rhecoeng.com"
+        pullSecret: |-
+          {{ .openshiftPullSecret | toString }}
+        aws_access_key_id: |-
+          {{ .awsKeyId | toString }}
+        aws_secret_access_key: |-
+          {{ .awsAccessKey | toString }}
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+        ssh-publickey: |-
+          {{ .sshPublicKey | toString }}
+        httpProxy: ""
+        httpsProxy: ""
+        noProxy: ""
+        additionalTrustBundle: ""
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  dataFrom:
+  - extract:
+      # Expects entries called: aws_access_key_id and aws_secret_access_key
+      key: secret/data/hub/aws
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+# For use when manually creating clusters with ACM
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  - secretKey: awsKeyId
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_access_key_id
+  - secretKey: awsAccessKey
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_secret_access_key
+  - secretKey: sshPublicKey
+    remoteRef:
+      key: secret/data/hub/publickey
+      property: content
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -229,7 +481,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: azure-us-acm-provision-edge-infra-creds
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -248,7 +500,7 @@ spec:
       key: secret/data/hub/azureOsServicePrincipal
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
+  secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore
   target:
@@ -282,7 +534,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-ap-acm-provision-edge-pull-secret
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -330,7 +582,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: azure-us-acm-provision-edge-pull-secret
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -373,17 +625,149 @@ spec:
         ssh-privatekey: |-
           {{ .sshPrivateKey | toString }}
 ---
-# Source: acm/templates/provision/clusterpool.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ .openshiftPullSecret | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ .openshiftPullSecret | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: acm-provision-edge
+    clusterGroup: region
+  name: aws-cd-one-w-pool-acm-provision-edge
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubAcceptsClient: true
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: acm-provision-on-deploy
+    clusterGroup: acm-provision-on-deploy
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubAcceptsClient: true
+---
+# Source: acm/templates/provision/managedclusterset.yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   annotations:
     cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-edge-broker
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: acm-provision-edge
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
+---
+# Source: acm/templates/provision/managedclusterset.yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  annotations:
+    cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-on-deploy-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: acm-provision-on-deploy
 ---
 # Source: acm/templates/multiclusterhub.yaml
 apiVersion: operator.open-cluster-management.io/v1
@@ -441,6 +825,22 @@ placementRef:
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: acm-provision-edge-clustergroup-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: acm-provision-on-deploy-placement-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: acm-provision-on-deploy-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: acm-provision-on-deploy-clustergroup-policy
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
@@ -507,6 +907,21 @@ spec:
   clusterSelector:
     matchLabels:
       clusterGroup: region
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: acm-provision-on-deploy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchLabels:
+      clusterGroup: acm-provision-on-deploy
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
@@ -747,6 +1162,102 @@ spec:
                   destination:
                     server: https://kubernetes.default.svc
                     namespace: mypattern-acm-provision-edge
+                  syncPolicy:
+                    automated:
+                      prune: false
+                      selfHeal: true
+                    retry:
+                      limit: 20
+                  ignoreDifferences:
+                  - group: apps
+                    kind: Deployment
+                    jsonPointers:
+                    - /spec/replicas
+                  - group: route.openshift.io
+                    kind: Route
+                    jsonPointers:
+                    - /status
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: acm-provision-on-deploy-clustergroup-policy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: acm-provision-on-deploy-clustergroup-config
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                apiVersion: argoproj.io/v1alpha1
+                kind: Application
+                metadata:
+                  name: mypattern-acm-provision-on-deploy
+                  namespace: openshift-gitops
+                  finalizers:
+                  - resources-finalizer.argocd.argoproj.io/foreground
+                spec:
+                  project: default
+                  source:
+                    repoURL: https://github.com/pattern-clone/mypattern
+                    targetRevision: main
+                    path: common/clustergroup
+                    helm:
+                      ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
+                      valueFiles:
+                      - "/values-global.yaml"
+                      - "/values-acm-provision-on-deploy.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-on-deploy.yaml'
+                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
+                      # hub's cluster version, whereas we want to include the spoke cluster version
+                      - '/values-{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}.yaml'
+                      parameters:
+                      - name: global.repoURL
+                        value: https://github.com/pattern-clone/mypattern
+                      - name: global.targetRevision
+                        value: main
+                      - name: global.namespace
+                        value: $ARGOCD_APP_NAMESPACE
+                      - name: global.pattern
+                        value: mypattern
+                      - name: global.hubClusterDomain
+                        value: apps.hub.example.com
+                      - name: global.localClusterDomain
+                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}'
+                      - name: global.clusterDomain
+                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
+                      - name: global.clusterVersion
+                        value: '{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
+                      - name: global.clusterPlatform
+                        value: aws
+                      - name: clusterGroup.name
+                        value: acm-provision-on-deploy
+                      - name: global.experimentalCapabilities
+                        value: 
+                  destination:
+                    server: https://kubernetes.default.svc
+                    namespace: mypattern-acm-provision-on-deploy
                   syncPolicy:
                     automated:
                       prune: false

--- a/common/tests/clustergroup-normal.expected.yaml
+++ b/common/tests/clustergroup-normal.expected.yaml
@@ -170,6 +170,14 @@ data:
       - acmlabels:
         - name: clusterGroup
           value: region
+        clusterDeployments:
+          myFirstCluster:
+            baseDomain: blueprints.rhecoeng.com
+            name: aws-cd-one-w-pool
+            openshiftVersion: 4.10.18
+            platform:
+              aws:
+                region: ap-southeast-1
         clusterPools:
           exampleAWSPool:
             baseDomain: blueprints.rhecoeng.com
@@ -202,6 +210,15 @@ data:
           value: "false"
         name: acm-provision-edge
         targetRevision: main
+      - clusterDeployments:
+          mySecondCluster:
+            baseDomain: blueprints.rhecoeng.com
+            name: aws-cd-two-wo-pool
+            openshiftVersion: 4.10.18
+            platform:
+              aws:
+                region: ap-southeast-3
+        name: acm-provision-on-deploy
       - helmOverrides:
         - name: clusterGroup.isHubCluster
           value: "false"
@@ -238,6 +255,8 @@ data:
       - exclude-og
       projects:
       - datacenter
+      scheduler:
+        mastersSchedulable: true
       sharedValueFiles:
       - /values/aws.yaml
       - /values/4.12.yaml
@@ -1226,6 +1245,14 @@ metadata:
 spec:
   targetNamespaces:
   - include-default-og
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: true
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+---
 # Source: acm/templates/provision/secrets-common.yaml
 apiVersion: v1
 kind: Secret
@@ -6,7 +18,7 @@ metadata:
   name: aws-ap-acm-provision-edge-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWFwJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAxCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDAKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTIKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz 
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWFwJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAxCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDAKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTIKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
 type: Opaque
 ---
 # Source: acm/templates/provision/secrets-common.yaml
@@ -16,7 +28,29 @@ metadata:
   name: azure-us-acm-provision-edge-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw== 
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
+type: Opaque
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-install-config
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+data:
+  # Base64 encoding of install-config yaml
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLW9uZS13LXBvb2wnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCmNvbXB1dGU6Ci0gaHlwZXJ0aHJlYWRpbmc6IEVuYWJsZWQKICBhcmNoaXRlY3R1cmU6IGFtZDY0CiAgbmFtZTogJ3dvcmtlcicKICByZXBsaWNhczogMwogIHBsYXRmb3JtOgogICAgYXdzOgogICAgICB0eXBlOiBtNS54bGFyZ2UKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTEKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
+type: Opaque
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+data:
+  # Base64 encoding of install-config yaml
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLXR3by13by1wb29sJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhd3M6CiAgICByZWdpb246IGFwLXNvdXRoZWFzdC0zCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
 type: Opaque
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
@@ -61,6 +95,64 @@ metadata:
 spec:
   clusterPoolName: azure-us-acm-provision-edge
 ---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+  labels:
+    vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  baseDomain: blueprints.rhecoeng.com
+  clusterName: aws-cd-one-w-pool-acm-provision-edge
+  installAttemptsLimit: 1
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws-cd-one-w-pool-acm-provision-edge-creds
+      region: ap-southeast-1
+  provisioning:
+    installConfigSecretRef:
+      name: aws-cd-one-w-pool-acm-provision-edge-install-config
+    sshPrivateKeySecretRef:
+      name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+    imageSetRef:
+      name: img4.10.18-multi-appsub
+  pullSecretRef:
+    name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+  labels:
+    vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  baseDomain: blueprints.rhecoeng.com
+  clusterName: aws-cd-two-wo-pool-acm-provision-on-deploy
+  installAttemptsLimit: 1
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+      region: ap-southeast-3
+  provisioning:
+    installConfigSecretRef:
+      name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+    sshPrivateKeySecretRef:
+      name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+    imageSetRef:
+      name: img4.10.18-multi-appsub
+  pullSecretRef:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+---
 # Source: acm/templates/provision/clusterpool.yaml
 apiVersion: hive.openshift.io/v1
 kind: ClusterPool
@@ -79,7 +171,7 @@ spec:
   runningCount: 0
   baseDomain: blueprints.rhecoeng.com
   installConfigSecretTemplateRef:
-    name: aws-ap-acm-provision-edge-install-config 
+    name: aws-ap-acm-provision-edge-install-config
   imageSetRef:
     name: img4.10.18-multi-appsub
   pullSecretRef:
@@ -109,7 +201,7 @@ spec:
   runningCount: 2
   baseDomain: blueprints.rhecoeng.com
   installConfigSecretTemplateRef:
-    name: azure-us-acm-provision-edge-install-config 
+    name: azure-us-acm-provision-edge-install-config
   imageSetRef:
     name: img4.10.18-multi-appsub
   pullSecretRef:
@@ -147,7 +239,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-ap-acm-provision-edge-infra-creds
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -170,11 +262,171 @@ spec:
       key: secret/data/hub/privatekey
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
+  secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore
   target:
     name: aws-ap-acm-provision-edge-infra-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cluster.open-cluster-management.io/credentials: ""
+          cluster.open-cluster-management.io/type: aws
+      data:
+        baseDomain: "blueprints.rhecoeng.com"
+        pullSecret: |-
+          {{ .openshiftPullSecret | toString }}
+        aws_access_key_id: |-
+          {{ .awsKeyId | toString }}
+        aws_secret_access_key: |-
+          {{ .awsAccessKey | toString }}
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+        ssh-publickey: |-
+          {{ .sshPublicKey | toString }}
+        httpProxy: ""
+        httpsProxy: ""
+        noProxy: ""
+        additionalTrustBundle: ""
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-creds
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  dataFrom:
+  - extract:
+      # Expects entries called: aws_access_key_id and aws_secret_access_key
+      key: secret/data/hub/aws
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+# For use when manually creating clusters with ACM
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  - secretKey: awsKeyId
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_access_key_id
+  - secretKey: awsAccessKey
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_secret_access_key
+  - secretKey: sshPublicKey
+    remoteRef:
+      key: secret/data/hub/publickey
+      property: content
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cluster.open-cluster-management.io/credentials: ""
+          cluster.open-cluster-management.io/type: aws
+      data:
+        baseDomain: "blueprints.rhecoeng.com"
+        pullSecret: |-
+          {{ .openshiftPullSecret | toString }}
+        aws_access_key_id: |-
+          {{ .awsKeyId | toString }}
+        aws_secret_access_key: |-
+          {{ .awsAccessKey | toString }}
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+        ssh-publickey: |-
+          {{ .sshPublicKey | toString }}
+        httpProxy: ""
+        httpsProxy: ""
+        noProxy: ""
+        additionalTrustBundle: ""
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  dataFrom:
+  - extract:
+      # Expects entries called: aws_access_key_id and aws_secret_access_key
+      key: secret/data/hub/aws
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+# For use when manually creating clusters with ACM
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  - secretKey: awsKeyId
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_access_key_id
+  - secretKey: awsAccessKey
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_secret_access_key
+  - secretKey: sshPublicKey
+    remoteRef:
+      key: secret/data/hub/publickey
+      property: content
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -229,7 +481,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: azure-us-acm-provision-edge-infra-creds
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -248,7 +500,7 @@ spec:
       key: secret/data/hub/azureOsServicePrincipal
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
+  secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore
   target:
@@ -282,7 +534,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-ap-acm-provision-edge-pull-secret
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -330,7 +582,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: azure-us-acm-provision-edge-pull-secret
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -373,17 +625,149 @@ spec:
         ssh-privatekey: |-
           {{ .sshPrivateKey | toString }}
 ---
-# Source: acm/templates/provision/clusterpool.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ .openshiftPullSecret | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ .openshiftPullSecret | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: acm-provision-edge
+    clusterGroup: region
+  name: aws-cd-one-w-pool-acm-provision-edge
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubAcceptsClient: true
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: acm-provision-on-deploy
+    clusterGroup: acm-provision-on-deploy
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubAcceptsClient: true
+---
+# Source: acm/templates/provision/managedclusterset.yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   annotations:
     cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-edge-broker
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: acm-provision-edge
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
+---
+# Source: acm/templates/provision/managedclusterset.yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  annotations:
+    cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-on-deploy-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: acm-provision-on-deploy
 ---
 # Source: acm/templates/multiclusterhub.yaml
 apiVersion: operator.open-cluster-management.io/v1
@@ -441,6 +825,22 @@ placementRef:
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: acm-provision-edge-clustergroup-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: acm-provision-on-deploy-placement-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: acm-provision-on-deploy-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: acm-provision-on-deploy-clustergroup-policy
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
@@ -507,6 +907,21 @@ spec:
   clusterSelector:
     matchLabels:
       clusterGroup: region
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: acm-provision-on-deploy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchLabels:
+      clusterGroup: acm-provision-on-deploy
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
@@ -747,6 +1162,102 @@ spec:
                   destination:
                     server: https://kubernetes.default.svc
                     namespace: mypattern-acm-provision-edge
+                  syncPolicy:
+                    automated:
+                      prune: false
+                      selfHeal: true
+                    retry:
+                      limit: 20
+                  ignoreDifferences:
+                  - group: apps
+                    kind: Deployment
+                    jsonPointers:
+                    - /spec/replicas
+                  - group: route.openshift.io
+                    kind: Route
+                    jsonPointers:
+                    - /status
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: acm-provision-on-deploy-clustergroup-policy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: acm-provision-on-deploy-clustergroup-config
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                apiVersion: argoproj.io/v1alpha1
+                kind: Application
+                metadata:
+                  name: mypattern-acm-provision-on-deploy
+                  namespace: openshift-gitops
+                  finalizers:
+                  - resources-finalizer.argocd.argoproj.io/foreground
+                spec:
+                  project: default
+                  source:
+                    repoURL: https://github.com/pattern-clone/mypattern
+                    targetRevision: main
+                    path: common/clustergroup
+                    helm:
+                      ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
+                      valueFiles:
+                      - "/values-global.yaml"
+                      - "/values-acm-provision-on-deploy.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-on-deploy.yaml'
+                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
+                      # hub's cluster version, whereas we want to include the spoke cluster version
+                      - '/values-{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}.yaml'
+                      parameters:
+                      - name: global.repoURL
+                        value: https://github.com/pattern-clone/mypattern
+                      - name: global.targetRevision
+                        value: main
+                      - name: global.namespace
+                        value: $ARGOCD_APP_NAMESPACE
+                      - name: global.pattern
+                        value: mypattern
+                      - name: global.hubClusterDomain
+                        value: apps.hub.example.com
+                      - name: global.localClusterDomain
+                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}'
+                      - name: global.clusterDomain
+                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
+                      - name: global.clusterVersion
+                        value: '{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
+                      - name: global.clusterPlatform
+                        value: aws
+                      - name: clusterGroup.name
+                        value: acm-provision-on-deploy
+                      - name: global.experimentalCapabilities
+                        value: 
+                  destination:
+                    server: https://kubernetes.default.svc
+                    namespace: mypattern-acm-provision-on-deploy
                   syncPolicy:
                     automated:
                       prune: false

--- a/tests/common-clustergroup-normal.expected.yaml
+++ b/tests/common-clustergroup-normal.expected.yaml
@@ -170,6 +170,14 @@ data:
       - acmlabels:
         - name: clusterGroup
           value: region
+        clusterDeployments:
+          myFirstCluster:
+            baseDomain: blueprints.rhecoeng.com
+            name: aws-cd-one-w-pool
+            openshiftVersion: 4.10.18
+            platform:
+              aws:
+                region: ap-southeast-1
         clusterPools:
           exampleAWSPool:
             baseDomain: blueprints.rhecoeng.com
@@ -202,6 +210,15 @@ data:
           value: "false"
         name: acm-provision-edge
         targetRevision: main
+      - clusterDeployments:
+          mySecondCluster:
+            baseDomain: blueprints.rhecoeng.com
+            name: aws-cd-two-wo-pool
+            openshiftVersion: 4.10.18
+            platform:
+              aws:
+                region: ap-southeast-3
+        name: acm-provision-on-deploy
       - helmOverrides:
         - name: clusterGroup.isHubCluster
           value: "false"
@@ -238,6 +255,8 @@ data:
       - exclude-og
       projects:
       - datacenter
+      scheduler:
+        mastersSchedulable: true
       sharedValueFiles:
       - /values/aws.yaml
       - /values/4.12.yaml
@@ -1223,6 +1242,14 @@ metadata:
 spec:
   targetNamespaces:
   - include-default-og
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: true
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
- **feat: add support for hive clusterdeployments creating spokes**
- **test: regenerated tests after clusterdeployment commit**
- **test: updated test-cased and regeneated expectations**
- **chore: added annotations controling gitops and fail for missing meta for clusterdeployments**
- **chore: removed managedclusterset spec**
- **Added support to enable user workloads in control plane nodes**
- **Added full support for the scheduler**
- **Simplified PR for auto approve install plans**
- **fix: when using clusterdeployments, secrets should exist in the cluster-namespace**
- **Fix CI issue**
- **Actually use adminServiceAccountName for the auto approve job**
- **Make sure that the if condition on chart split is not always true**
- **Bump super-linter from 5 to 6**
- **Drop some validations for now**
- **Add some debugging to the chart split action**
- **Use a specific git version when running git subtree split**
- **Release clustergroup v0.8.6**
- **Add a sudo to apt-get command**
- **Add some READMEs in the individual charts**
- **Fix super-linter issues and upgrade local super-linter target**
- **Skip unreachable spokes when setting up vault**
- **Update tests after common rebase**
