### PR TITLE
Use expandvars

### DIFF
--- a/tests/interop/test_validate_hub_site_components.py
+++ b/tests/interop/test_validate_hub_site_components.py
@@ -114,7 +114,8 @@ def test_validate_acm_self_registration_managed_clusters(openshift_dyn_client):
     logger.info("Check ACM self registration for edge site")
 
     kubefile = os.getenv("KUBECONFIG_EDGE")
-    with open(kubefile) as stream:
+    kubefile_exp = os.path.expandvars(kubefile)
+    with open(kubefile_exp) as stream:
         try:
             out = yaml.safe_load(stream)
             site_name = out["clusters"][0]["name"]


### PR DESCRIPTION
Addresses failure seen running in pipeline: 

2024-06-07 03:04:58,428 INFO     >       with open(kubefile) as stream:
2024-06-07 03:04:58,428 INFO     E       FileNotFoundError: [Errno 2] No such file or directory: '$TEFLO_WORKSPACE/kube/kubeconfig-edge'


