### PR TITLE
Comment out subscriptions in values-group-one.yaml

### DIFF
--- a/values-group-one.yaml
+++ b/values-group-one.yaml
@@ -10,7 +10,8 @@ clusterGroup:
     - config-demo
     - hello-world
     - golang-external-secrets
-  subscriptions:
+  # The only subscription on spokes is gitops which gets managed by ACM
+  # subscriptions:
   projects:
     - eso
     - config-demo


### PR DESCRIPTION
Gitops on spokes might complain with multisource about this:

  Error: failed parsing --set data: unable to parse key: interface conversion: interface {} is nil, not map[string]interface {}

We do not need subscriptions on the spokes so let's comment it out
explaining why it is not needed.
