### PR TITLE
Fix vars that were erroneously dropped

### DIFF
--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -75,6 +75,12 @@ podman run -it --rm --pull=newer \
 	-e EXTRA_HELM_OPTS \
 	-e EXTRA_PLAYBOOK_OPTS \
 	-e KUBECONFIG \
+	-e K8S_AUTH_HOST \
+	-e K8S_AUTH_VERIFY_SSL \
+	-e K8S_AUTH_SSL_CA_CERT \
+	-e K8S_AUTH_USERNAME \
+	-e K8S_AUTH_PASSWORD \
+	-e K8S_AUTH_TOKEN \
 	${PKI_HOST_MOUNT_ARGS} \
 	-v "${HOME}":"${HOME}" \
 	-v "${HOME}":/pattern-home \


### PR DESCRIPTION
In 98d43123834d24fafb670e4127244cddc07763d5 (Fix pki bind mount when
using podman machine) we erroneously dropped some K8S_* variables.

Reported-by: Andrew Beekhof <beekhof@redhat.com>
