### PR TITLE
Revert "Update acm to v2.12"

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -11,7 +11,8 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.12
+      channel: release-2.11
+      #csv: advanced-cluster-management.v2.6.1
   projects:
     - hub
     - config-demo


### PR DESCRIPTION
This reverts commit 3010375aaf4b127373099d2a9dcae418201aac28.

This mistake is on me. I thought I checked that acm-2.12 was available
all the way back to 4.12 but it clearly it isn't.
