### PR TITLE
Wait some more before giving up

### DIFF
--- a/common/scripts/deploy-pattern.sh
+++ b/common/scripts/deploy-pattern.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -o pipefail
 
-RUNS=5
+RUNS=10
+WAIT=15
 # Retry five times because the CRD might not be fully installed yet
 echo -n "Installing pattern: "
 for i in $(seq 1 ${RUNS}); do \
@@ -13,7 +14,7 @@ for i in $(seq 1 ${RUNS}); do \
         break;
     else
         echo -n "."
-        sleep 10
+        sleep "${WAIT}"
     fi
 done
 


### PR DESCRIPTION
Yukin observed a case on a baremetal server where the install failed
with:

    make -f common/Makefile operator-deploy
    make[1]: Entering directory '/home/fedora/validated_patterns/multicloud-gitops'
    Checking repository:
      https://github.com/validatedpatterns-workspace/multicloud-gitops - branch 'qe_test-18760': OK
    Checking cluster:
      cluster-info: OK
      storageclass: OK
    Installing pattern: ....Installation failed [5/5]. Error:
    WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/fedora/rhvpsno2-intel-18760/auth/kubeconfig
    WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/fedora/rhvpsno2-intel-18760/auth/kubeconfig
    Pulled: quay.io/hybridcloudpatterns/pattern-install:0.0.7
    Digest: sha256:b845f86c735478cfd44b0b43842697851cec64737c737bd18a872fa86bb0484d
    customresourcedefinition.apiextensions.k8s.io/patterns.gitops.hybrid-cloud-patterns.io unchanged
    configmap/patterns-operator-config unchanged
    pattern.gitops.hybrid-cloud-patterns.io/multicloud-gitops created
    subscription.operators.coreos.com/patterns-operator unchanged
    make[1]: *** [common/Makefile:71: operator-deploy] Error 1
    make[1]: Leaving directory '/home/fedora/validated_patterns/multicloud-gitops'
    make: *** [Makefile:12: operator-deploy] Error 2

In fact the install proceeded just okay, we just gave up too early.
Let's double the amount of times we wait for this and also increase the
wait in between tries by 5 seconds. Hopefully this should cover these
edge cases.
