### PR TITLE
Add override for 4.18

### DIFF
--- a/values-4.18-hub.yaml
+++ b/values-4.18-hub.yaml
@@ -1,0 +1,6 @@
+clusterGroup:
+  subscriptions:
+    acm:
+      name: advanced-cluster-management
+      namespace: open-cluster-management
+      channel: release-2.12


### PR DESCRIPTION
According to https://access.redhat.com/labs/ocpouic/?operator=advanced-cluster-management&&upgrade_path=4.16 to 4.18
ACM channel-2.11 does not exist on 4.18.

Let's just override that.
