### PR TITLE
Introduce DISABLE_VALIDATE_ORIGIN variable

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -4,6 +4,14 @@ ifneq ($(origin TARGET_SITE), undefined)
   TARGET_SITE_OPT=--set main.clusterGroupName=$(TARGET_SITE)
 endif
 
+# Set this to true if you want to skip any origin validation
+DISABLE_VALIDATE_ORIGIN ?= false
+ifeq ($(DISABLE_VALIDATE_ORIGIN),true)
+  VALIDATE_ORIGIN := 
+else
+  VALIDATE_ORIGIN := validate-origin
+endif
+
 # This variable can be set in order to pass additional helm arguments from the
 # the command line. I.e. we can set things without having to tweak values files
 EXTRA_HELM_OPTS ?=
@@ -71,7 +79,7 @@ preview-%:
 	@common/scripts/preview.sh $(CLUSTERGROUP) $* $(TARGET_REPO) $(TARGET_BRANCH)
 
 .PHONY: operator-deploy
-operator-deploy operator-upgrade: validate-prereq validate-origin validate-cluster ## runs helm install
+operator-deploy operator-upgrade: validate-prereq $(VALIDATE_ORIGIN) validate-cluster ## runs helm install
 	@common/scripts/deploy-pattern.sh $(NAME) $(PATTERN_INSTALL_CHART) $(HELM_OPTS)
 
 .PHONY: uninstall

--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -96,6 +96,7 @@ podman run -it --rm --pull=newer \
     -e KUBECONFIG \
     -e PATTERN_INSTALL_CHART \
     -e PATTERN_DISCONNECTED_HOME \
+    -e DISABLE_VALIDATE_ORIGIN \
     -e K8S_AUTH_HOST \
     -e K8S_AUTH_VERIFY_SSL \
     -e K8S_AUTH_SSL_CA_CERT \


### PR DESCRIPTION
With this one can disable the origin validation entirely.
This can come in handy when setting things up for testing the
existance of the remote branch is too onerous (i.e. private git repo)

Now you can run:

export DISABLE_VALIDATE_ORIGIN=true
./pattern.sh make install

and the check will be skipped
