### PR TITLE
Use ACM 2.12 on 4.19

### DIFF
--- a/values-4.19-hub.yaml
+++ b/values-4.19-hub.yaml
@@ -1,0 +1,6 @@
+clusterGroup:
+  subscriptions:
+    acm:
+      name: advanced-cluster-management
+      namespace: open-cluster-management
+      channel: release-2.12


### PR DESCRIPTION
We mimick the same approach we use on 4.18.
Eventually we will want to switch to 1.13 but for now this is the least
intrusive choice.
