### PR TITLE
feat: Add https with edge termination to routes

### DIFF
--- a/charts/all/config-demo/templates/config-demo-route.yaml
+++ b/charts/all/config-demo/templates/config-demo-route.yaml
@@ -12,3 +12,6 @@ spec:
     name: config-demo
     weight: 100
   wildcardPolicy: None
+  tls:
+    insecureEdgeTerminationPolicy: Allow
+    termination: edge

--- a/charts/all/hello-world/templates/hello-world-route.yaml
+++ b/charts/all/hello-world/templates/hello-world-route.yaml
@@ -12,3 +12,6 @@ spec:
     name: hello-world
     weight: 100
   wildcardPolicy: None
+  tls:
+    insecureEdgeTerminationPolicy: Allow
+    termination: edge


### PR DESCRIPTION
Allow the current http as well for backward compatibility for now

resolves #471
