### PR TITLE
Use new argoProject(s) naming

### DIFF
--- a/values-group-one.yaml
+++ b/values-group-one.yaml
@@ -12,7 +12,7 @@ clusterGroup:
     - golang-external-secrets
   # The only subscription on spokes is gitops which gets managed by ACM
   # subscriptions:
-  projects:
+  argoProjects:
     - eso
     - config-demo
     - hello-world
@@ -20,18 +20,18 @@ clusterGroup:
     golang-external-secrets:
       name: golang-external-secrets
       namespace: golang-external-secrets
-      project: eso
+      argoProject: eso
       chart: golang-external-secrets
       chartVersion: 0.1.*
     config-demo:
       name: config-demo
       namespace: config-demo
-      project: config-demo
+      argoProject: config-demo
       path: charts/all/config-demo
     hello-world:
       name: hello-world
       namespace: hello-world
-      project: hello-world
+      argoProject: hello-world
       path: charts/all/hello-world
   imperative:
     # NOTE: We *must* use lists and not hashes. As hashes lose ordering once parsed by helm

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -13,7 +13,7 @@ clusterGroup:
       namespace: open-cluster-management
       channel: release-2.14
       # csv: advanced-cluster-management.v2.6.1
-  projects:
+  argoProjects:
     - hub
     - config-demo
     - hello-world
@@ -42,30 +42,30 @@ clusterGroup:
     acm:
       name: acm
       namespace: open-cluster-management
-      project: hub
+      argoProject: hub
       chart: acm
       chartVersion: 0.1.*
     vault:
       name: vault
       namespace: vault
-      project: hub
+      argoProject: hub
       chart: hashicorp-vault
       chartVersion: 0.1.*
     golang-external-secrets:
       name: golang-external-secrets
       namespace: golang-external-secrets
-      project: hub
+      argoProject: hub
       chart: golang-external-secrets
       chartVersion: 0.1.*
     config-demo:
       name: config-demo
       namespace: config-demo
-      project: config-demo
+      argoProject: config-demo
       path: charts/all/config-demo
     hello-world:
       name: hello-world
       namespace: hello-world
-      project: hello-world
+      argoProject: hello-world
       path: charts/all/hello-world
   imperative:
     # NOTE: We *must* use lists and not hashes. As hashes lose ordering once parsed by helm


### PR DESCRIPTION
Since clustergroup chart 0.9.33 we can now use the clearer
argoProject(s) naming to reference argo projects.
