### PR TITLE
run patternizer upgrade command

### DIFF
--- a/Makefile-common
+++ b/Makefile-common
@@ -1,6 +1,6 @@
 MAKEFLAGS += --no-print-directory
-ANSIBLE_STDOUT_CALLBACK ?= null # null silences all ansible output. Override this with default, minimal, oneline, etc. when debugging.
-ANSIBLE_RUN := ANSIBLE_STDOUT_CALLBACK=$(ANSIBLE_STDOUT_CALLBACK) ansible-playbook $(EXTRA_PLAYBOOK_OPTS)
+ANSIBLE_STDOUT_CALLBACK ?= rhvp.cluster_utils.readable
+ANSIBLE_RUN ?= ANSIBLE_STDOUT_CALLBACK=$(ANSIBLE_STDOUT_CALLBACK) ansible-playbook $(EXTRA_PLAYBOOK_OPTS)
 DOCS_URL := https://validatedpatterns.io/blog/2025-08-29-new-common-makefile-structure/
 
 .PHONY: help
@@ -20,9 +20,9 @@ operator-deploy operator-upgrade: ## Installs/updates the pattern on a cluster (
 .PHONY: install
 install: pattern-install ## Installs the pattern onto a cluster (Loads secrets as well if configured)
 
-.PHONY: uninstall ## Prints a notice that patterns cannot currently be uninstalled
-uninstall:
-	@echo "Uninstall is not possible at the moment so this target is empty. We are working to implement it as well as we can."
+.PHONY: uninstall
+uninstall: ## (EXPERIMENTAL) See https://validatedpatterns.io/blog/2026-02-16-pattern-uninstall/.
+	@$(ANSIBLE_RUN) rhvp.cluster_utils.uninstall
 
 .PHONY: pattern-install
 pattern-install:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,9 +4,12 @@ retry_files_enabled=False
 # Retry files disabled to avoid cluttering CI/CD environments
 interpreter_python=auto_silent
 timeout=30
-library=~/.ansible/plugins/modules:./ansible/plugins/modules:./common/ansible/plugins/modules:/usr/share/ansible/plugins/modules
-roles_path=~/.ansible/roles:./ansible/roles:./common/ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-filter_plugins=~/.ansible/plugins/filter:./ansible/plugins/filter:./common/ansible/plugins/filter:/usr/share/ansible/plugins/filter
+library=~/.ansible/plugins/modules:./ansible/plugins/modules:/usr/share/ansible/plugins/modules
+roles_path=~/.ansible/roles:./ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+filter_plugins=~/.ansible/plugins/filter:./ansible/plugins/filter:/usr/share/ansible/plugins/filter
 # use the collections from the util. container,
 # change below if you want to test local collections
 collections_path=/usr/share/ansible/collections
+
+[inventory]
+inventory_unparsed_warning=False


### PR DESCRIPTION
The latest upgrade does two main things:

1. Uninstall is actually using the uninstall playbook rather than just printing a message
2. ansible.cfg drops references to common folder