### PR TITLE
Simplify git logic in patternizer-update

### DIFF
--- a/.github/workflows/patternizer-update.yml
+++ b/.github/workflows/patternizer-update.yml
@@ -45,22 +45,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Check if the branch already exists on the remote
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-            git reset --hard origin/main
-            git checkout main -- .
-            # Re-run the update on the branch
-            podman run --pull=newer -v "$PWD:$PWD:z" -w "$PWD" quay.io/validatedpatterns/patternizer:latest update
-            git add -A
-            if git diff --cached --quiet; then
-              echo "Existing PR branch is already up to date"
-              exit 0
-            fi
-          else
-            git checkout -b "$BRANCH"
-          fi
+          # Create or reset the branch to current HEAD (main) and switch to it.
+          # -B handles both cases: creates if missing, resets if it exists.
+          # Staged changes are preserved since the target commit is the same.
+          git checkout -B "$BRANCH"
 
           git commit -m "chore: update patternizer-managed files"
           git push --force-with-lease origin "$BRANCH"


### PR DESCRIPTION
If the remote branch automated/patternizer-update already existed, the
old code did git checkout "$BRANCH" after the patternizer had already
modified files in the working tree. Git refused because uncommitted
changes would be overwritten

So it would fail like this:

    ```
    Changes detected after patternizer update:
    .claude/skills/pattern-author/SKILL.md
    .claude/skills/pattern-author/reference.md
    .cursor/skills/pattern-author/SKILL.md
    .cursor/skills/pattern-author/reference.md
    pattern.sh
    From https://github.com/validatedpatterns/multicloud-gitops
     * branch            automated/patternizer-update -> FETCH_HEAD
    error: Your local changes to the following files would be overwritten by checkout:
	    .claude/skills/pattern-author/SKILL.md
	    .claude/skills/pattern-author/reference.md
	    .cursor/skills/pattern-author/SKILL.md
	    .cursor/skills/pattern-author/reference.md
    Please commit your changes or stash them before you switch branches.
    Aborting
    ```
