### PR TITLE
feat: Change azure node type to newer generation (v4)

### DIFF
--- a/pattern-metadata.yaml
+++ b/pattern-metadata.yaml
@@ -23,7 +23,7 @@ requirements:
           type: n1-standard-8
         azure:
           replicas: 3
-          type: Standard_D8s_v3
+          type: Standard_D8s_v4
         aws:
           replicas: 3
           type: m5.2xlarge
@@ -34,7 +34,7 @@ requirements:
           type: n1-standard-4
         azure:
           replicas: 3
-          type: Standard_D4s_v3
+          type: Standard_D4s_v4
         aws:
           replicas: 3
           type: m5.xlarge


### PR DESCRIPTION
Gen V4 is supported and has better availability in most regions
